### PR TITLE
Contains and Not Contains expressions

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
@@ -88,6 +88,10 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return String.valueOf(value).startsWith((String) literal.value());
       case NOT_STARTS_WITH:
         return !String.valueOf(value).startsWith((String) literal.value());
+      case CONTAINS:
+        return String.valueOf(value).contains((String) literal.value());
+      case NOT_CONTAINS:
+        return !String.valueOf(value).contains((String) literal.value());
       default:
         throw new IllegalStateException("Invalid operation for BoundLiteralPredicate: " + op());
     }
@@ -159,6 +163,10 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
         return term() + " startsWith \"" + literal + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal + "\"";
+      case CONTAINS:
+        return term() + " contains \"" + literal + "\"";
+      case NOT_CONTAINS:
+        return term() + " notContains \"" + literal + "\"";
       case IN:
         return term() + " in { " + literal + " }";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -156,5 +156,16 @@ public class Evaluator implements Serializable {
     public <T> Boolean notStartsWith(Bound<T> valueExpr, Literal<T> lit) {
       return !startsWith(valueExpr, lit);
     }
+
+    @Override
+    public <T> Boolean contains(Bound<T> valueExpr, Literal<T> lit) {
+      T evalRes = valueExpr.eval(struct);
+      return evalRes != null && ((String) evalRes).contains((String) lit.value());
+    }
+
+    @Override
+    public <T> Boolean notContains(Bound<T> valueExpr, Literal<T> lit) {
+      return !contains(valueExpr, lit);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -44,6 +44,8 @@ public interface Expression extends Serializable {
     OR,
     STARTS_WITH,
     NOT_STARTS_WITH,
+    CONTAINS,
+    NOT_CONTAINS,
     COUNT,
     COUNT_STAR,
     MAX,
@@ -90,6 +92,10 @@ public interface Expression extends Serializable {
           return Operation.NOT_STARTS_WITH;
         case NOT_STARTS_WITH:
           return Operation.STARTS_WITH;
+        case CONTAINS:
+          return Operation.NOT_CONTAINS;
+        case NOT_CONTAINS:
+          return Operation.CONTAINS;
         default:
           throw new IllegalArgumentException("No negation for operation: " + this);
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -333,6 +333,8 @@ public class ExpressionUtil {
         case NOT_EQ:
         case STARTS_WITH:
         case NOT_STARTS_WITH:
+        case CONTAINS:
+        case NOT_CONTAINS:
           return new UnboundPredicate<>(
               pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
         case IN:
@@ -492,7 +494,7 @@ public class ExpressionUtil {
         case CONTAINS:
           return term + " CONTAINS " + sanitize(pred.literal(), nowMicros, today);
         case NOT_CONTAINS:
-            return term + " NOT CONTAINS " + sanitize(pred.literal(), nowMicros, today);
+          return term + " NOT CONTAINS " + sanitize(pred.literal(), nowMicros, today);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -433,6 +433,10 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case CONTAINS:
+          return term + " CONTAINS " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_CONTAINS:
+          return term + " NOT CONTAINS " + value((BoundLiteralPredicate<?>) pred);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());
@@ -485,6 +489,10 @@ public class ExpressionUtil {
           return term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
         case NOT_STARTS_WITH:
           return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case CONTAINS:
+          return term + " CONTAINS " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_CONTAINS:
+            return term + " NOT CONTAINS " + sanitize(pred.literal(), nowMicros, today);
         default:
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -126,6 +126,16 @@ public class ExpressionVisitors {
           "notStartsWith expression is not supported by the visitor");
     }
 
+    public <T> R contains(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "contains expression is not supported by the visitor");
+    }
+
+    public <T> R notContains(BoundReference<T> ref, Literal<T> lit) {
+      throw new UnsupportedOperationException(
+          "notContains expression is not supported by the visitor");
+    }
+
     /**
      * Handle a non-reference value in this visitor.
      *
@@ -166,6 +176,10 @@ public class ExpressionVisitors {
             return startsWith((BoundReference<T>) pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains((BoundReference<T>) pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -266,6 +280,14 @@ public class ExpressionVisitors {
       throw new UnsupportedOperationException("Unsupported operation.");
     }
 
+    public <T> R contains(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
+    public <T> R notContains(Bound<T> expr, Literal<T> lit) {
+      throw new UnsupportedOperationException("Unsupported operation.");
+    }
+
     @Override
     public <T> R predicate(BoundPredicate<T> pred) {
       if (pred.isLiteralPredicate()) {
@@ -287,6 +309,10 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains(pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -491,6 +491,10 @@ public class ExpressionVisitors {
             return startsWith(pred.term(), literalPred.literal());
           case NOT_STARTS_WITH:
             return notStartsWith(pred.term(), literalPred.literal());
+          case CONTAINS:
+            return contains(pred.term(), literalPred.literal());
+          case NOT_CONTAINS:
+            return notContains(pred.term(), literalPred.literal());
           default:
             throw new IllegalStateException(
                 "Invalid operation for BoundLiteralPredicate: " + pred.op());
@@ -579,6 +583,14 @@ public class ExpressionVisitors {
     }
 
     public <T> R notStartsWith(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R contains(BoundTerm<T> term, Literal<T> lit) {
+      return null;
+    }
+
+    public <T> R notContains(BoundTerm<T> term, Literal<T> lit) {
       return null;
     }
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -207,15 +207,15 @@ public class Expressions {
   }
 
   public static UnboundPredicate<String> contains(UnboundTerm<String> expr, String value) {
-      return new UnboundPredicate<>(Expression.Operation.CONTAINS, expr, value);
+    return new UnboundPredicate<>(Expression.Operation.CONTAINS, expr, value);
   }
 
   public static UnboundPredicate<String> notContains(String name, String value) {
-      return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, ref(name), value);
+    return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, ref(name), value);
   }
 
   public static UnboundPredicate<String> notContains(UnboundTerm<String> expr, String value) {
-      return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, expr, value);
+    return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, expr, value);
   }
 
   public static <T> UnboundPredicate<T> in(String name, T... values) {

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -202,6 +202,22 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, expr, value);
   }
 
+  public static UnboundPredicate<String> contains(String name, String value) {
+    return new UnboundPredicate<>(Expression.Operation.CONTAINS, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> contains(UnboundTerm<String> expr, String value) {
+      return new UnboundPredicate<>(Expression.Operation.CONTAINS, expr, value);
+  }
+
+  public static UnboundPredicate<String> notContains(String name, String value) {
+      return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, ref(name), value);
+  }
+
+  public static UnboundPredicate<String> notContains(UnboundTerm<String> expr, String value) {
+      return new UnboundPredicate<>(Expression.Operation.NOT_CONTAINS, expr, value);
+  }
+
   public static <T> UnboundPredicate<T> in(String name, T... values) {
     return predicate(Operation.IN, name, Lists.newArrayList(values));
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -484,43 +484,6 @@ public class InclusiveMetricsEvaluator {
 
     @Override
     public <T> Boolean notContains(Bound<T> term, Literal<T> lit) {
-      // the only transforms that produce strings are truncate and identity, which work with this
-      int id = term.ref().fieldId();
-      if (mayContainNull(id)) {
-        return ROWS_MIGHT_MATCH;
-      }
-
-      String substring = (String) lit.value();
-      CharSequence lower = (CharSequence) lowerBound(term);
-      CharSequence upper = (CharSequence) upperBound(term);
-      if (null == lower
-          || null == upper
-          || lower.length() < substring.length()
-          || upper.length() < substring.length()) {
-        return ROWS_MIGHT_MATCH;
-      }
-
-      String lowerStr = lower.toString();
-      String upperStr = upper.toString();
-
-      int lowerFirstOccurrence = lowerStr.indexOf(substring);
-      int upperFirstOccurrence = upperStr.indexOf(substring);
-
-      if (lowerFirstOccurrence < 0 || lowerFirstOccurrence != upperFirstOccurrence) {
-        return ROWS_MIGHT_MATCH;
-      }
-
-      if (lowerStr
-          .substring(0, lowerFirstOccurrence)
-          .equals(upperStr.substring(0, upperFirstOccurrence))) {
-        // both bounds contain the substring at the same position and have the same prefix
-        // until then, so all rows must contain the substring and therefore do not satisfy
-        // the predicate. note that we test this condition with the first occurrence of the
-        // substring only, which is fine because it's impossible that a later occurrence
-        // would have satisfied this condition but an earlier one would not have
-        return ROWS_CANNOT_MATCH;
-      }
-
       return ROWS_MIGHT_MATCH;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -484,6 +484,8 @@ public class InclusiveMetricsEvaluator {
 
     @Override
     public <T> Boolean notContains(Bound<T> term, Literal<T> lit) {
+      // TODO: Efficiently handle cases that definitely cannot match, such as notContains("ab") when
+      // bounds are ["xabc", "xabyz"]
       return ROWS_MIGHT_MATCH;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -471,6 +471,59 @@ public class InclusiveMetricsEvaluator {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean contains(Bound<T> term, Literal<T> lit) {
+      // the only transforms that produce strings are truncate and identity, which work with this
+      int id = term.ref().fieldId();
+      if (containsNullsOnly(id)) {
+        return ROWS_CANNOT_MATCH;
+      }
+
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(Bound<T> term, Literal<T> lit) {
+      // the only transforms that produce strings are truncate and identity, which work with this
+      int id = term.ref().fieldId();
+      if (mayContainNull(id)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      String substring = (String) lit.value();
+      CharSequence lower = (CharSequence) lowerBound(term);
+      CharSequence upper = (CharSequence) upperBound(term);
+      if (null == lower
+          || null == upper
+          || lower.length() < substring.length()
+          || upper.length() < substring.length()) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      String lowerStr = lower.toString();
+      String upperStr = upper.toString();
+
+      int lowerFirstOccurrence = lowerStr.indexOf(substring);
+      int upperFirstOccurrence = upperStr.indexOf(substring);
+
+      if (lowerFirstOccurrence < 0 || lowerFirstOccurrence != upperFirstOccurrence) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      if (lowerStr
+          .substring(0, lowerFirstOccurrence)
+          .equals(upperStr.substring(0, upperFirstOccurrence))) {
+        // both bounds contain the substring at the same position and have the same prefix
+        // until then, so all rows must contain the substring and therefore do not satisfy
+        // the predicate. note that we test this condition with the first occurrence of the
+        // substring only, which is fine because it's impossible that a later occurrence
+        // would have satisfied this condition but an earlier one would not have
+        return ROWS_CANNOT_MATCH;
+      }
+
+      return ROWS_MIGHT_MATCH;
+    }
+
     private boolean mayContainNull(Integer id) {
       return nullCounts == null || !nullCounts.containsKey(id) || nullCounts.get(id) != 0;
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -400,6 +400,22 @@ public class ManifestEvaluator {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      int pos = Accessors.toPosition(ref.accessor());
+      PartitionFieldSummary fieldStats = stats.get(pos);
+      if (fieldStats.lowerBound() == null) {
+        return ROWS_CANNOT_MATCH; // values are all null, cannot contain the literal
+      }
+
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
     private boolean allValuesAreNull(PartitionFieldSummary summary, Type.TypeID typeId) {
       // containsNull encodes whether at least one partition value is null,
       // lowerBound is null if all partition values are null

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -413,6 +413,8 @@ public class ManifestEvaluator {
 
     @Override
     public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      // TODO: Efficiently handle cases that definitely cannot match, such as notContains("ab") when
+      // bounds are ["xabc", "xabyz"]
       return ROWS_MIGHT_MATCH;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -223,6 +223,20 @@ public class ResidualEvaluator implements Serializable {
     }
 
     @Override
+    public <T> Expression contains(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).contains((String) lit.value())
+          ? alwaysTrue()
+          : alwaysFalse();
+    }
+
+    @Override
+    public <T> Expression notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ((String) ref.eval(struct)).contains((String) lit.value())
+          ? alwaysFalse()
+          : alwaysTrue();
+    }
+
+    @Override
     @SuppressWarnings("unchecked")
     public <T> Expression predicate(BoundPredicate<T> pred) {
       // Get the strict projection and inclusive projection of this predicate in partition data,

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -462,18 +462,22 @@ public class StrictMetricsEvaluator {
 
     @Override
     public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
+      // TODO: Handle cases that definitely match, such as startsWith("x") when the bounds are
+      // ["xa", "xz"]
       return ROWS_MIGHT_NOT_MATCH;
     }
 
     @Override
     public <T> Boolean notStartsWith(BoundReference<T> ref, Literal<T> lit) {
-      // TODO: Handle cases that definitely cannot match, such as notStartsWith("x") when the bounds
-      // are ["a", "b"].
+      // TODO: Handle cases that definitely match, such as notStartsWith("x") when the bounds are
+      // ["a", "b"].
       return ROWS_MIGHT_NOT_MATCH;
     }
 
     @Override
     public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      // TODO: Efficiently handle cases that definitely match, such as contains("ab") when bounds
+      // are ["xabc", "xabyz"]
       return ROWS_MIGHT_NOT_MATCH;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -472,6 +472,16 @@ public class StrictMetricsEvaluator {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_NOT_MATCH;
+    }
+
     private boolean isNestedColumn(int id) {
       return struct.field(id) == null;
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -168,6 +168,14 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
           boundTerm.type());
     }
 
+    if (op() == Operation.CONTAINS || op() == Operation.NOT_CONTAINS) {
+      ValidationException.check(
+          boundTerm.type().equals(Types.StringType.get()),
+          "Term for CONTAINS or NOT_CONTAINS must produce a string: %s: %s",
+          boundTerm,
+          boundTerm.type());
+    }
+
     Literal<T> lit = literal().to(boundTerm.type());
 
     if (lit == null) {
@@ -276,6 +284,10 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
         return term() + " startsWith \"" + literal() + "\"";
       case NOT_STARTS_WITH:
         return term() + " notStartsWith \"" + literal() + "\"";
+      case CONTAINS:
+        return term() + " contains \"" + literal() + "\"";
+      case NOT_CONTAINS:
+        return term() + " notContains \"" + literal() + "\"";
       case IN:
         return term() + " in (" + COMMA.join(literals()) + ")";
       case NOT_IN:

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -219,8 +219,6 @@ class ProjectionUtil {
         // there is no predicate that guarantees equality because adjacent values transform to the
         // same partition
         return null;
-      case NOT_STARTS_WITH:
-        return predicate(Expression.Operation.NOT_STARTS_WITH, name, transform.apply(boundary));
       default:
         return null;
     }

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -219,6 +219,8 @@ class ProjectionUtil {
         // there is no predicate that guarantees equality because adjacent values transform to the
         // same partition
         return null;
+      case NOT_STARTS_WITH:
+        return predicate(Expression.Operation.NOT_STARTS_WITH, name, transform.apply(boundary));
       default:
         return null;
     }

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -382,7 +382,7 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
               return Expressions.notEqual(name, pred.literal().value());
             }
 
-            return Expressions.predicate(pred.op(), name, apply(pred.literal().value()).toString());
+            return ProjectionUtil.truncateArrayStrict(name, pred, this);
 
           default:
             return ProjectionUtil.truncateArrayStrict(name, pred, this);

--- a/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Truncate.java
@@ -382,7 +382,7 @@ class Truncate<T> implements Transform<T, T>, Function<T, T> {
               return Expressions.notEqual(name, pred.literal().value());
             }
 
-            return ProjectionUtil.truncateArrayStrict(name, pred, this);
+            return Expressions.predicate(pred.op(), name, apply(pred.literal().value()).toString());
 
           default:
             return ProjectionUtil.truncateArrayStrict(name, pred, this);

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -434,6 +434,16 @@ public class AllManifestsTable extends BaseMetadataTable {
         return ROWS_MIGHT_MATCH;
       }
 
+      @Override
+      public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       /**
        * Comparison of snapshot reference and literal, using long comparator.
        *

--- a/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseEntriesTable.java
@@ -251,6 +251,16 @@ abstract class BaseEntriesTable extends BaseMetadataTable {
         return ROWS_MIGHT_MATCH;
       }
 
+      @Override
+      public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       private <T> boolean fileContent(BoundReference<T> ref) {
         return ref.fieldId() == DataFile.CONTENT.fieldId();
       }

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -347,6 +347,8 @@ public class ExpressionParser {
       case NOT_EQ:
       case STARTS_WITH:
       case NOT_STARTS_WITH:
+      case CONTAINS:
+      case NOT_CONTAINS:
         // literal predicates
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkFilters.java
@@ -45,6 +45,7 @@ public class FlinkFilters {
   private FlinkFilters() {}
 
   private static final Pattern STARTS_WITH_PATTERN = Pattern.compile("([^%]+)%");
+  private static final Pattern CONTAINS_PATTERN = Pattern.compile("%([^%]+)%");
 
   private static final Map<FunctionDefinition, Operation> FILTERS =
       ImmutableMap.<FunctionDefinition, Operation>builder()
@@ -178,14 +179,20 @@ public class FlinkFilters {
               lit -> {
                 if (lit instanceof String) {
                   String pattern = (String) lit;
-                  Matcher matcher = STARTS_WITH_PATTERN.matcher(pattern);
                   // exclude special char of LIKE
                   // '_' is the wildcard of the SQL LIKE
-                  if (!pattern.contains("_") && matcher.matches()) {
-                    return Optional.of(Expressions.startsWith(name, matcher.group(1)));
+                  if (!pattern.contains("_")) {
+                    Matcher startsWithMatcher = STARTS_WITH_PATTERN.matcher(pattern);
+                    if (startsWithMatcher.matches()) {
+                      return Optional.of(Expressions.startsWith(name, startsWithMatcher.group(1)));
+                    }
+
+                    Matcher containsMatcher = CONTAINS_PATTERN.matcher(pattern);
+                    if (containsMatcher.matches()) {
+                      return Optional.of(Expressions.contains(name, containsMatcher.group(1)));
+                    }
                   }
                 }
-
                 return Optional.empty();
               });
     }

--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -270,6 +270,22 @@ class ExpressionToSearchArgument
   }
 
   @Override
+  public <T> Action contains(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down CONTAINS operator to ORC, so return TruthValue.YES_NO_NULL which
+    // signifies
+    // that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
+  public <T> Action notContains(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down NOT_CONTAINS operator to ORC, so return TruthValue.YES_NO_NULL which
+    // signifies
+    // that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
   public <T> Action predicate(BoundPredicate<T> pred) {
     if (UNSUPPORTED_TYPES.contains(pred.ref().type().typeId())
         || !(pred.term() instanceof BoundReference)) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -259,6 +259,18 @@ public class ParquetBloomRowGroupFilter {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      // bloom filter is based on hash and cannot eliminate based on contains
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      // bloom filter is based on hash and cannot eliminate based on contains
+      return ROWS_MIGHT_MATCH;
+    }
+
     private BloomFilter loadBloomFilter(int id) {
       if (bloomCache.containsKey(id)) {
         return bloomCache.get(id);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -408,40 +408,14 @@ public class ParquetDictionaryRowGroupFilter {
 
     @Override
     public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
-      int id = ref.fieldId();
-
-      Boolean hasNonDictPage = isFallback.get(id);
-      if (hasNonDictPage == null || hasNonDictPage) {
-        return ROWS_MIGHT_MATCH;
-      }
-
-      Set<T> dictionary = dict(id, lit.comparator());
-      for (T item : dictionary) {
-        if (item.toString().contains(lit.value().toString())) {
-          return ROWS_MIGHT_MATCH;
-        }
-      }
-
-      return ROWS_CANNOT_MATCH;
+      // TODO: Efficiently determine whether some dictionary value contains the literal
+      return ROWS_MIGHT_MATCH;
     }
 
     @Override
     public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
-      int id = ref.fieldId();
-
-      Boolean hasNonDictPage = isFallback.get(id);
-      if (hasNonDictPage == null || hasNonDictPage) {
-        return ROWS_MIGHT_MATCH;
-      }
-
-      Set<T> dictionary = dict(id, lit.comparator());
-      for (T item : dictionary) {
-        if (!item.toString().contains(lit.value().toString())) {
-          return ROWS_MIGHT_MATCH;
-        }
-      }
-
-      return ROWS_CANNOT_MATCH;
+      // TODO: Efficiently determine whether some dictionary value does not contain the literal
+      return ROWS_MIGHT_MATCH;
     }
 
     @SuppressWarnings("unchecked")

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -406,6 +406,44 @@ public class ParquetDictionaryRowGroupFilter {
       return ROWS_CANNOT_MATCH;
     }
 
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      Set<T> dictionary = dict(id, lit.comparator());
+      for (T item : dictionary) {
+        if (item.toString().contains(lit.value().toString())) {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      Set<T> dictionary = dict(id, lit.comparator());
+      for (T item : dictionary) {
+        if (!item.toString().contains(lit.value().toString())) {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      return ROWS_CANNOT_MATCH;
+    }
+
     @SuppressWarnings("unchecked")
     private <T> Set<T> dict(int id, Comparator<T> comparator) {
       Preconditions.checkNotNull(dictionaries, "Dictionary is required");

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -570,6 +570,8 @@ public class ParquetMetricsRowGroupFilter {
 
     @Override
     public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      // TODO: Efficiently handle cases that definitely cannot match, such as notContains("ab") when
+      // bounds are ["xabc", "xabyz"]
       return ROWS_MIGHT_MATCH;
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -549,6 +549,30 @@ public class ParquetMetricsRowGroupFilter {
       return ROWS_MIGHT_MATCH;
     }
 
+    @Override
+    public <T> Boolean contains(BoundReference<T> ref, Literal<T> lit) {
+      int id = ref.fieldId();
+
+      Long valueCount = valueCounts.get(id);
+      if (valueCount == null) {
+        // the column is not present and is all nulls
+        return ROWS_CANNOT_MATCH;
+      }
+
+      @SuppressWarnings("unchecked")
+      Statistics<Binary> colStats = (Statistics<Binary>) stats.get(id);
+      if (colStats != null && !colStats.isEmpty() && allNulls(colStats, valueCount)) {
+        return ROWS_CANNOT_MATCH;
+      }
+
+      return ROWS_MIGHT_MATCH;
+    }
+
+    @Override
+    public <T> Boolean notContains(BoundReference<T> ref, Literal<T> lit) {
+      return ROWS_MIGHT_MATCH;
+    }
+
     @SuppressWarnings("unchecked")
     private <T> T min(Statistics<?> statistics, int id) {
       return (T) conversions.get(id).apply(statistics.genericGetMin());

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -674,6 +674,10 @@ public class Spark3Util {
           return sqlString(pred.term()) + " LIKE '" + pred.literal().value() + "%'";
         case NOT_STARTS_WITH:
           return sqlString(pred.term()) + " NOT LIKE '" + pred.literal().value() + "%'";
+        case CONTAINS:
+          return sqlString(pred.term()) + " LIKE '%" + pred.literal().value() + "%'";
+        case NOT_CONTAINS:
+          return sqlString(pred.term()) + " NOT LIKE '%" + pred.literal().value() + "%'";
         case IN:
           return sqlString(pred.term()) + " IN (" + sqlString(pred.literals()) + ")";
         case NOT_IN:

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.expressions.Expressions.and;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
@@ -68,6 +69,7 @@ import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
 import org.apache.spark.sql.sources.Or;
+import org.apache.spark.sql.sources.StringContains;
 import org.apache.spark.sql.sources.StringStartsWith;
 
 public class SparkFilters {
@@ -95,6 +97,7 @@ public class SparkFilters {
           .put(Or.class, Operation.OR)
           .put(Not.class, Operation.NOT)
           .put(StringStartsWith.class, Operation.STARTS_WITH)
+          .put(StringContains.class, Operation.CONTAINS)
           .buildOrThrow();
 
   public static Expression convert(Filter[] filters) {
@@ -219,6 +222,12 @@ public class SparkFilters {
           {
             StringStartsWith stringStartsWith = (StringStartsWith) filter;
             return startsWith(unquote(stringStartsWith.attribute()), stringStartsWith.value());
+          }
+
+        case CONTAINS:
+          {
+            StringContains stringContains = (StringContains) filter;
+            return contains(unquote(stringContains.attribute()), stringContains.value());
           }
       }
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.bucket;
+import static org.apache.iceberg.expressions.Expressions.contains;
 import static org.apache.iceberg.expressions.Expressions.day;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
@@ -88,6 +89,7 @@ public class SparkV2Filters {
   private static final String OR = "OR";
   private static final String NOT = "NOT";
   private static final String STARTS_WITH = "STARTS_WITH";
+  private static final String CONTAINS = "CONTAINS";
 
   private static final Map<String, Operation> FILTERS =
       ImmutableMap.<String, Operation>builder()
@@ -107,6 +109,7 @@ public class SparkV2Filters {
           .put(OR, Operation.OR)
           .put(NOT, Operation.NOT)
           .put(STARTS_WITH, Operation.STARTS_WITH)
+          .put(CONTAINS, Operation.CONTAINS)
           .buildOrThrow();
 
   private SparkV2Filters() {}
@@ -301,8 +304,14 @@ public class SparkV2Filters {
           }
 
         case STARTS_WITH:
+          {
+            String colName = SparkUtil.toColumnName(leftChild(predicate));
+            return startsWith(colName, convertLiteral(rightChild(predicate)).toString());
+          }
+
+        case CONTAINS:
           String colName = SparkUtil.toColumnName(leftChild(predicate));
-          return startsWith(colName, convertLiteral(rightChild(predicate)).toString());
+          return contains(colName, convertLiteral(rightChild(predicate)).toString());
       }
     }
 


### PR DESCRIPTION
If you partition by a string column on which you do `contains` filters, pruning does not occur during scan planning at all and queries are surprisingly slow. However, Spark actually exposes `StringContains` as a filter it's able to push down to data sources - so this is possible to achieve and integrate with Spark.

(There's also `endsWith`, that's potentially less contentious because it's easier and more efficient to check. And there's also the question of generalising)