### PR TITLE
Hive: Synchronize HiveTableOperations encryption state + concurrent encryption-key test

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -88,11 +88,16 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   private final KeyManagementClient keyManagementClient;
   private final ClientPool<IMetaStoreClient, TException> metaClients;
 
+  // Concurrent commits on a shared table refresh and rebuild the encryption state. All access to
+  // the encryption fields below is guarded by encryptionLock -- a dedicated lock, not `this`, so
+  // this internal locking can't contend with external code that locks the TableOperations. Only
+  // tableKeyId is volatile, for the lock-free fast path in io()/encryption() (set once from null,
+  // never reset).
+  private final Object encryptionLock = new Object();
+  private volatile String tableKeyId;
   private EncryptionManager encryptionManager;
   private EncryptingFileIO encryptingFileIO;
-  private String tableKeyId;
   private int encryptionDekLength;
-
   private List<EncryptedKey> encryptedKeys = List.of();
 
   protected HiveTableOperations(
@@ -130,40 +135,42 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       return fileIO;
     }
 
-    if (encryptingFileIO == null) {
-      encryptingFileIO = EncryptingFileIO.combine(fileIO, encryption());
-    }
+    synchronized (encryptionLock) {
+      if (encryptingFileIO == null) {
+        encryptingFileIO = EncryptingFileIO.combine(fileIO, encryption());
+      }
 
-    return encryptingFileIO;
+      return encryptingFileIO;
+    }
   }
 
   @Override
   public EncryptionManager encryption() {
-    if (encryptionManager != null) {
-      return encryptionManager;
-    }
-
-    if (tableKeyId != null) {
-      Preconditions.checkArgument(
-          keyManagementClient != null,
-          "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
-          CatalogProperties.ENCRYPTION_KMS_IMPL);
-
-      Map<String, String> encryptionProperties =
-          ImmutableMap.of(
-              TableProperties.ENCRYPTION_TABLE_KEY,
-              tableKeyId,
-              TableProperties.ENCRYPTION_DEK_LENGTH,
-              String.valueOf(encryptionDekLength));
-
-      encryptionManager =
-          EncryptionUtil.createEncryptionManager(
-              encryptedKeys, encryptionProperties, keyManagementClient);
-    } else {
+    if (tableKeyId == null) {
       return PlaintextEncryptionManager.instance();
     }
 
-    return encryptionManager;
+    synchronized (encryptionLock) {
+      if (encryptionManager == null) {
+        Preconditions.checkArgument(
+            keyManagementClient != null,
+            "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
+            CatalogProperties.ENCRYPTION_KMS_IMPL);
+
+        Map<String, String> encryptionProperties =
+            ImmutableMap.of(
+                TableProperties.ENCRYPTION_TABLE_KEY,
+                tableKeyId,
+                TableProperties.ENCRYPTION_DEK_LENGTH,
+                String.valueOf(encryptionDekLength));
+
+        encryptionManager =
+            EncryptionUtil.createEncryptionManager(
+                encryptedKeys, encryptionProperties, keyManagementClient);
+      }
+
+      return encryptionManager;
+    }
   }
 
   @Override
@@ -208,31 +215,33 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
     if (tableKeyIdFromHMS != null) {
       checkIntegrityForEncryption(tableKeyIdFromHMS, dekLengthFromHMS, metadataHashFromHMS);
 
-      tableKeyId = tableKeyIdFromHMS;
-      encryptionDekLength =
-          (dekLengthFromHMS != null)
-              ? Integer.parseInt(dekLengthFromHMS)
-              : TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT;
+      synchronized (encryptionLock) {
+        encryptionDekLength =
+            (dekLengthFromHMS != null)
+                ? Integer.parseInt(dekLengthFromHMS)
+                : TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT;
 
-      encryptedKeys =
-          Optional.ofNullable(current().encryptionKeys())
-              .map(Lists::newLinkedList)
-              .orElseGet(Lists::newLinkedList);
+        encryptedKeys =
+            Optional.ofNullable(current().encryptionKeys())
+                .map(Lists::newLinkedList)
+                .orElseGet(Lists::newLinkedList);
 
-      if (encryptionManager != null) {
-        Set<String> keyIdsFromMetadata =
-            encryptedKeys.stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
+        if (encryptionManager != null) {
+          Set<String> keyIdsFromMetadata =
+              encryptedKeys.stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
 
-        for (EncryptedKey keyFromEM : EncryptionUtil.encryptionKeys(encryptionManager).values()) {
-          if (!keyIdsFromMetadata.contains(keyFromEM.keyId())) {
-            encryptedKeys.add(keyFromEM);
+          for (EncryptedKey keyFromEM : EncryptionUtil.encryptionKeys(encryptionManager).values()) {
+            if (!keyIdsFromMetadata.contains(keyFromEM.keyId())) {
+              encryptedKeys.add(keyFromEM);
+            }
           }
         }
-      }
 
-      // Force re-creation of encryption manager with updated keys
-      encryptingFileIO = null;
-      encryptionManager = null;
+        // Force re-creation of encryption manager with updated keys
+        encryptingFileIO = null;
+        encryptionManager = null;
+        tableKeyId = tableKeyIdFromHMS;
+      }
     }
   }
 
@@ -558,16 +567,18 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   }
 
   private void encryptionPropsFromMetadata(Map<String, String> tableProperties) {
-    if (tableKeyId == null) {
-      tableKeyId = tableProperties.get(TableProperties.ENCRYPTION_TABLE_KEY);
-    }
+    synchronized (encryptionLock) {
+      if (tableKeyId == null) {
+        tableKeyId = tableProperties.get(TableProperties.ENCRYPTION_TABLE_KEY);
+      }
 
-    if (tableKeyId != null && encryptionDekLength <= 0) {
-      encryptionDekLength =
-          PropertyUtil.propertyAsInt(
-              tableProperties,
-              TableProperties.ENCRYPTION_DEK_LENGTH,
-              TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT);
+      if (tableKeyId != null && encryptionDekLength <= 0) {
+        encryptionDekLength =
+            PropertyUtil.propertyAsInt(
+                tableProperties,
+                TableProperties.ENCRYPTION_DEK_LENGTH,
+                TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT);
+      }
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -19,6 +19,9 @@
 package org.apache.iceberg.spark.sql;
 
 import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,6 +31,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ChecksumFileSystem;
@@ -41,20 +46,24 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Tasks;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
 import org.junit.jupiter.api.AfterEach;
@@ -109,6 +118,13 @@ public class TestTableEncryption extends CatalogTestBase {
     return Streams.stream(table.newScan().planFiles())
         .map(FileScanTask::file)
         .collect(Collectors.toList());
+  }
+
+  private static List<FileScanTask> planSnapshot(Table table, long snapshotId) throws IOException {
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(snapshotId).planFiles()) {
+      return ImmutableList.copyOf(tasks);
+    }
   }
 
   @TestTemplate
@@ -192,6 +208,51 @@ public class TestTableEncryption extends CatalogTestBase {
 
     Table afterSecondReplace = validationCatalog.loadTable(tableIdent);
     assertThat(currentDataFiles(afterSecondReplace)).hasSize(1);
+  }
+
+  @TestTemplate
+  public void testConcurrentAppendsPreserveEncryptionKeys() throws IOException {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    // High retry ceiling so concurrent commits contending on one table lock do not exhaust retries.
+    table
+        .updateProperties()
+        .set(COMMIT_NUM_RETRIES, "500")
+        .set(COMMIT_MIN_RETRY_WAIT_MS, "25")
+        .set(COMMIT_MAX_RETRY_WAIT_MS, "25")
+        .commit();
+
+    List<DataFile> initialFiles = currentDataFiles(table);
+    int initialSnapshotCount = (int) Streams.stream(table.snapshots()).count();
+    DataFile file = initialFiles.get(0);
+
+    int threadCount = 4;
+    int commitsPerThread = 40;
+    Tasks.range(threadCount)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(
+            MoreExecutors.getExitingExecutorService(
+                (ThreadPoolExecutor) Executors.newFixedThreadPool(threadCount)))
+        .run(
+            index -> {
+              for (int i = 0; i < commitsPerThread; i++) {
+                table.newFastAppend().appendFile(file).commit();
+              }
+            });
+
+    Table reloaded = validationCatalog.loadTable(tableIdent);
+    assertThat(reloaded.snapshots()).hasSize(initialSnapshotCount + threadCount * commitsPerThread);
+
+    // Every committed snapshot must stay readable: a dropped key makes scan planning fail while
+    // decrypting the manifest list.
+    for (Snapshot snapshot : reloaded.snapshots()) {
+      assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
+    }
+
+    assertThat(currentDataFiles(reloaded))
+        .hasSize(initialFiles.size() + threadCount * commitsPerThread);
   }
 
   @TestTemplate


### PR DESCRIPTION
> **⚠️ Depends on PR A and PR B — INTENTIONALLY RED on its own.**
> This PR is the concurrency-hardening layer in a stack:
> - **PR A** — `StandardEncryptionManager` thread-safety (manager thread-safety)
> - **PR B** — `SnapshotProducer` key persistence (key-persistence relocation; also removes the `doCommit` key-copy and adds `testTransactionInterleavedWithDirectCommitOnSharedTable`)
> - **PR C** — this PR: `HiveTableOperations` encryption-state synchronization + `testConcurrentAppendsPreserveEncryptionKeys`
>
> The new Spark concurrency test (`testConcurrentAppendsPreserveEncryptionKeys`) **stays RED on `main` until both A and B merge**, and goes green once the full stack is in place. This is expected and by design — please do not treat the red test as a regression.
>
> **Merge order: A → B → C.**
>
> **Rebase note:** because this PR is based off `main` (not stacked on B), it will need a trivial rebase after B merges — both B and C add the same `planSnapshot` helper to `TestTableEncryption`.

## What this does

### `HiveTableOperations` — synchronization only
Concurrent commits on a shared table refresh and rebuild the encryption state. This PR makes that state access thread-safe, and nothing else:
- Adds a dedicated `encryptionLock` (a private lock object, not `this`, so internal locking can't contend with external code that locks the `TableOperations`).
- Makes `tableKeyId` `volatile` for the lock-free fast path in `io()`/`encryption()` (set once from null, never reset).
- Synchronizes `io()`, `encryption()`, `doRefresh`, and `encryptionPropsFromMetadata` on `encryptionLock`.
- The `doRefresh` key-merge logic is kept **byte-for-byte identical to `main`** (same `keyIdsFromMetadata` set, same `EncryptionUtil.encryptionKeys(...)` loop, same `Optional.ofNullable(current().encryptionKeys())...` and the same `// Force re-creation of encryption manager with updated keys` comment) — only wrapped in the lock.

`doCommit` is unchanged from `main` (its key-copy behavior is removed by PR B, not here).

### Spark `TestTableEncryption`
- Adds a `planSnapshot` helper.
- Adds `testConcurrentAppendsPreserveEncryptionKeys`.

## Verification (this PR's bar: compiles + spotlessCheck)
- `:iceberg-hive-metastore:compileJava` + `:iceberg-hive-metastore:spotlessCheck` — **BUILD SUCCESSFUL**
- `:iceberg-spark:iceberg-spark-4.1_2.13:compileTestJava` + `:iceberg-spark:iceberg-spark-4.1_2.13:spotlessCheck` — **BUILD SUCCESSFUL**

🤖 Generated with [Claude Code](https://claude.com/claude-code)