### PR TITLE
Core, Hive, Spark: relocate manifest-list key persistence to snapshot apply

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -46,8 +46,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptingFileIO;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.events.CreateSnapshotEvent;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.exceptions.CleanableFailure;
@@ -113,6 +117,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private final Map<String, String> manifestWriterProps;
   private MetricsReporter reporter = LoggingMetricsReporter.instance();
   private volatile Long snapshotId = null;
+  private EncryptionManager applyEncryptionManager;
   private TableMetadata base;
   private boolean stageOnly = false;
   private Consumer<String> deleteFunc = defaultDelete;
@@ -303,11 +308,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
     OutputFile manifestList = manifestListPath();
 
+    this.applyEncryptionManager = ops.encryption();
     ManifestListWriter writer =
         ManifestLists.write(
             ops.current().formatVersion(),
             manifestList,
-            ops.encryption(),
+            applyEncryptionManager,
             snapshotId(),
             parentSnapshotId,
             sequenceNumber,
@@ -499,10 +505,13 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                   if (base.snapshot(newSnapshot.snapshotId()) != null) {
                     // this is a rollback operation
                     update.setBranchSnapshot(newSnapshot.snapshotId(), targetBranch);
-                  } else if (stageOnly) {
-                    update.addSnapshot(newSnapshot);
                   } else {
-                    update.setBranchSnapshot(newSnapshot, targetBranch);
+                    addEncryptionKeys(update, newSnapshot);
+                    if (stageOnly) {
+                      update.addSnapshot(newSnapshot);
+                    } else {
+                      update.setBranchSnapshot(newSnapshot, targetBranch);
+                    }
                   }
 
                   TableMetadata updated = update.build();
@@ -568,6 +577,28 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     } catch (Throwable e) {
       LOG.warn("Failed to notify event listeners", e);
     }
+  }
+
+  private void addEncryptionKeys(TableMetadata.Builder update, Snapshot snapshot) {
+    if (snapshot.keyId() == null
+        || !(applyEncryptionManager instanceof StandardEncryptionManager)) {
+      return;
+    }
+
+    Map<String, EncryptedKey> keys = EncryptionUtil.encryptionKeys(applyEncryptionManager);
+
+    EncryptedKey manifestListKey = keys.get(snapshot.keyId());
+    Preconditions.checkState(
+        manifestListKey != null, "Missing manifest list key metadata with id %s", snapshot.keyId());
+
+    EncryptedKey keyEncryptionKey = keys.get(manifestListKey.encryptedById());
+    Preconditions.checkState(
+        keyEncryptionKey != null,
+        "Missing key encryption key with id %s",
+        manifestListKey.encryptedById());
+
+    update.addEncryptionKey(manifestListKey);
+    update.addEncryptionKey(keyEncryptionKey);
   }
 
   private void notifyListeners() {

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
-import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -240,34 +239,18 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   @Override
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
     boolean newTable = base == null;
-    final TableMetadata tableMetadata;
     encryptionPropsFromMetadata(metadata.properties());
 
-    String newMetadataLocation;
-    EncryptionManager encrManager = encryption();
-    if (encrManager instanceof StandardEncryptionManager) {
-      // Add new encryption keys to the metadata
-      TableMetadata.Builder builder = TableMetadata.buildFrom(metadata);
-      for (Map.Entry<String, EncryptedKey> entry :
-          EncryptionUtil.encryptionKeys(encrManager).entrySet()) {
-        builder.addEncryptionKey(entry.getValue());
-      }
+    String newMetadataLocation = writeNewMetadataIfRequired(newTable, metadata);
 
-      tableMetadata = builder.build();
-    } else {
-      tableMetadata = metadata;
-    }
-
-    newMetadataLocation = writeNewMetadataIfRequired(newTable, tableMetadata);
-
-    boolean hiveEngineEnabled = hiveEngineEnabled(tableMetadata, conf);
+    boolean hiveEngineEnabled = hiveEngineEnabled(metadata, conf);
     boolean keepHiveStats = conf.getBoolean(ConfigProperties.KEEP_HIVE_STATS, false);
 
     BaseMetastoreOperations.CommitStatus commitStatus =
         BaseMetastoreOperations.CommitStatus.FAILURE;
     boolean updateHiveTable = false;
 
-    HiveLock lock = lockObject(base != null ? base : tableMetadata);
+    HiveLock lock = lockObject(base != null ? base : metadata);
     try {
       lock.lock();
 
@@ -291,14 +274,14 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       } else {
         tbl =
             newHmsTable(
-                tableMetadata.property(HiveCatalog.HMS_TABLE_OWNER, HiveHadoopUtil.currentUser()));
+                metadata.property(HiveCatalog.HMS_TABLE_OWNER, HiveHadoopUtil.currentUser()));
         LOG.debug("Committing new table: {}", fullName);
       }
 
       tbl.setSd(
           HiveOperationsBase.storageDescriptor(
-              tableMetadata.schema(),
-              tableMetadata.location(),
+              metadata.schema(),
+              metadata.location(),
               hiveEngineEnabled)); // set to pickup any schema changes
 
       String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
@@ -314,7 +297,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       if (base != null) {
         removedProps =
             base.properties().keySet().stream()
-                .filter(key -> !tableMetadata.properties().containsKey(key))
+                .filter(key -> !metadata.properties().containsKey(key))
                 .collect(Collectors.toSet());
 
         Preconditions.checkArgument(
@@ -331,7 +314,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       HMSTablePropertyHelper.updateHmsTableForIcebergTable(
           newMetadataLocation,
           tbl,
-          tableMetadata,
+          metadata,
           removedProps,
           hiveEngineEnabled,
           maxHiveTablePropertySize,
@@ -388,7 +371,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
           // issue for example, and triggers this exception. So we need double-check to make sure
           // this is really a concurrent modification. Hitting this exception means no pending
           // requests, if any, can succeed later, so it's safe to check status in strict mode
-          commitStatus = checkCommitStatusStrict(newMetadataLocation, tableMetadata);
+          commitStatus = checkCommitStatusStrict(newMetadataLocation, metadata);
           if (commitStatus == BaseMetastoreOperations.CommitStatus.FAILURE) {
             throw new CommitFailedException(
                 e, "The table %s.%s has been modified concurrently", database, tableName);
@@ -399,7 +382,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
               database,
               tableName,
               e);
-          commitStatus = checkCommitStatus(newMetadataLocation, tableMetadata);
+          commitStatus = checkCommitStatus(newMetadataLocation, metadata);
         }
 
         switch (commitStatus) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -41,11 +41,13 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.parquet.Parquet;
@@ -109,6 +111,13 @@ public class TestTableEncryption extends CatalogTestBase {
     return Streams.stream(table.newScan().planFiles())
         .map(FileScanTask::file)
         .collect(Collectors.toList());
+  }
+
+  private static List<FileScanTask> planSnapshot(Table table, long snapshotId) throws IOException {
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(snapshotId).planFiles()) {
+      return ImmutableList.copyOf(tasks);
+    }
   }
 
   @TestTemplate
@@ -192,6 +201,28 @@ public class TestTableEncryption extends CatalogTestBase {
 
     Table afterSecondReplace = validationCatalog.loadTable(tableIdent);
     assertThat(currentDataFiles(afterSecondReplace)).hasSize(1);
+  }
+
+  @TestTemplate
+  public void testTransactionInterleavedWithDirectCommitOnSharedTable() throws IOException {
+    validationCatalog.initialize(catalogName, catalogConfig);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    DataFile file = currentDataFiles(table).get(0);
+
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(file).commit();
+
+    // A direct commit on the same instance lands between the transaction's operations.
+    table.newFastAppend().appendFile(file).commit();
+
+    transaction.newFastAppend().appendFile(file).commit();
+    transaction.commitTransaction();
+
+    Table reloaded = validationCatalog.loadTable(tableIdent);
+    for (Snapshot snapshot : reloaded.snapshots()) {
+      assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
+    }
   }
 
   @TestTemplate


### PR DESCRIPTION
## What

Relocates manifest-list encryption key persistence from Hive commit time to snapshot-apply time, and drops the now-redundant Hive key-copy.

- **Core (`SnapshotProducer`)** — captures the `EncryptionManager` used to write the manifest list and, at commit-refresh time, persists the snapshot's manifest-list key and its wrapping key encryption key into `TableMetadata` via `addEncryptionKeys(...)`. Keys are now durably recorded on the snapshot's metadata at apply time.
- **Hive (`HiveTableOperations.doCommit`)** — removes the per-commit block that copied all `EncryptionUtil.encryptionKeys(...)` into the metadata before writing. That copy is redundant now that `SnapshotProducer` persists the keys, so `doCommit` reverts to operating on the incoming `metadata` directly (and the now-unused `StandardEncryptionManager` import is removed).
- **Spark (`TestTableEncryption`)** — adds a deterministic, single-threaded guardrail test `testTransactionInterleavedWithDirectCommitOnSharedTable` (plus a `planSnapshot(...)` helper) that interleaves a transaction with a direct commit on a shared `Table` and asserts every snapshot stays scannable. This is the deterministic guardrail for the `doRefresh` key-merge: it passes standalone on `main` because `SnapshotProducer` persistence plus main's existing `doRefresh` key-merge carry the transaction's uncommitted key.

## Stack

This is **PR B of three stacked encryption-concurrency PRs**. Merge order **A → B → C**:

- **A** — EncryptionManager thread-safety.
- **B (this PR)** — SnapshotProducer persists manifest-list keys into table metadata at snapshot-apply time; drops the redundant Hive `doCommit` key-copy; adds the deterministic guardrail test.
- **C** — `HiveTableOperations` concurrency lock (`encryptionLock`/`volatile`/`synchronized`) and the multi-threaded concurrent test; **depends on A + B**.

**A and B are independent and can be reviewed/merged on their own.** C depends on both.

## Deviation from the source branch

`SnapshotProducer.addEncryptionKeys(...)` uses the existing map accessor `EncryptionUtil.encryptionKeys(EncryptionManager)` (reading the two keys out of the returned `Map<String, EncryptedKey>`) rather than a new single-key accessor `EncryptionUtil.encryptionKey(manager, id)` that belongs to sibling PR A. This keeps B standalone-mergeable on `main`; behavior is identical.

## Testing

- `./gradlew :iceberg-core:test` — passes.
- `./gradlew :iceberg-hive-metastore:compileJava :iceberg-hive-metastore:spotlessCheck` — passes.
- `./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:test --tests "org.apache.iceberg.spark.sql.TestTableEncryption"` — all 14 templates pass, including the new `testTransactionInterleavedWithDirectCommitOnSharedTable`.