### PR TITLE
Core: Make StandardEncryptionManager thread-safe

### DIFF
--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.encryption;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Base64;
@@ -31,6 +33,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.ByteBuffers;
@@ -95,6 +98,10 @@ public class StandardEncryptionManager implements EncryptionManager {
     }
   }
 
+  private synchronized void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+  }
+
   @Override
   public NativeEncryptionOutputFile encrypt(OutputFile plainOutput) {
     return new StandardEncryptedOutputFile(plainOutput, dataKeyLength);
@@ -115,7 +122,7 @@ public class StandardEncryptionManager implements EncryptionManager {
     return Iterables.transform(encrypted, this::decrypt);
   }
 
-  private LoadingCache<String, ByteBuffer> unwrappedKeyCache() {
+  private synchronized LoadingCache<String, ByteBuffer> unwrappedKeyCache() {
     if (this.unwrappedKeyCache == null) {
       this.unwrappedKeyCache =
           Caffeine.newBuilder()
@@ -153,11 +160,11 @@ public class StandardEncryptionManager implements EncryptionManager {
     return kmsClient.unwrapKey(wrappedSecretKey, tableKeyId);
   }
 
-  Map<String, EncryptedKey> encryptionKeys() {
-    return encryptionKeys;
+  synchronized Map<String, EncryptedKey> encryptionKeys() {
+    return ImmutableMap.copyOf(encryptionKeys);
   }
 
-  String keyEncryptionKeyID() {
+  synchronized String keyEncryptionKeyID() {
     // Find unexpired key encryption key
     for (String keyID : encryptionKeys.keySet()) {
       EncryptedKey key = encryptionKeys.get(keyID);
@@ -193,7 +200,7 @@ public class StandardEncryptionManager implements EncryptionManager {
     return System.currentTimeMillis() + testTimeShift;
   }
 
-  ByteBuffer encryptedByKey(String manifestListKeyID) {
+  synchronized ByteBuffer encryptedByKey(String manifestListKeyID) {
     EncryptedKey encryptedKeyMetadata = encryptionKeys.get(manifestListKeyID);
 
     Preconditions.checkState(
@@ -209,7 +216,7 @@ public class StandardEncryptionManager implements EncryptionManager {
     return unwrappedKeyCache().get(encryptedKeyMetadata.encryptedById());
   }
 
-  public String addManifestListKeyMetadata(NativeEncryptionKeyMetadata keyMetadata) {
+  public synchronized String addManifestListKeyMetadata(NativeEncryptionKeyMetadata keyMetadata) {
     String manifestListKeyID = generateKeyId();
     String keyEncryptionKeyID = keyEncryptionKeyID();
     String keyEncryptionKeyTimestamp =

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.encryption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+public class TestStandardEncryptionManagerConcurrency {
+
+  private static final int THREADS = 4;
+  private static final int KEYS_PER_THREAD = 50;
+  private static final int ROUNDS = 300;
+
+  @Test
+  public void testConcurrentMintingIsThreadSafe() throws Exception {
+    StandardEncryptionManager manager = newManager();
+
+    List<String> keyIds = Lists.newArrayList();
+    for (List<String> perThread :
+        runConcurrently(
+            () -> {
+              List<String> ids = Lists.newArrayList();
+              for (int i = 0; i < KEYS_PER_THREAD; i++) {
+                ids.add(manager.addManifestListKeyMetadata(keyMetadata()));
+                manager.encryptionKeys().forEach((id, key) -> {}); // concurrent read must not throw
+              }
+              return ids;
+            })) {
+      keyIds.addAll(perThread);
+    }
+
+    // No lost updates or duplicate ids under concurrency, and every minted key resolves.
+    assertThat(Set.copyOf(keyIds)).hasSize(THREADS * KEYS_PER_THREAD);
+    for (String keyId : keyIds) {
+      assertThat(manager.encryptedByKey(keyId)).isNotNull();
+    }
+
+    // keyEncryptionKeyID()'s check-then-mint is atomic: exactly one key encryption key is created.
+    long kekCount =
+        manager.encryptionKeys().values().stream()
+            .filter(key -> key.encryptedById().equals(UnitestKMS.MASTER_KEY_NAME1))
+            .count();
+    assertThat(kekCount).isEqualTo(1L);
+  }
+
+  @Test
+  public void testConcurrentSerializationWhileMintingStaysConsistent() throws Exception {
+    StandardEncryptionManager manager = newManager();
+    List<String> seeded = Lists.newArrayList();
+    for (int i = 0; i < 10; i++) {
+      seeded.add(manager.addManifestListKeyMetadata(keyMetadata()));
+    }
+
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    CountDownLatch start = new CountDownLatch(1);
+    Thread minter =
+        new Thread(
+            () -> {
+              try {
+                start.await();
+                for (int i = 0; i < ROUNDS; i++) {
+                  manager.addManifestListKeyMetadata(keyMetadata());
+                }
+              } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+              }
+            });
+
+    minter.start();
+    start.countDown();
+    // writeObject is synchronized, so serialization never traverses the key map mid-put: every
+    // round trip is a complete, still-functional snapshot rather than a corrupt stream.
+    for (int i = 0; i < ROUNDS; i++) {
+      assertThat(roundTrip(manager).encryptionKeys().keySet()).containsAll(seeded);
+    }
+    minter.join(TimeUnit.SECONDS.toMillis(30));
+
+    assertThat(failure.get()).isNull();
+  }
+
+  private static StandardEncryptionManager newManager() {
+    return (StandardEncryptionManager) EncryptionTestHelpers.createEncryptionManager();
+  }
+
+  private static NativeEncryptionKeyMetadata keyMetadata() {
+    return new StandardKeyMetadata(new byte[16], new byte[16]);
+  }
+
+  private static List<List<String>> runConcurrently(Callable<List<String>> task) throws Exception {
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      CyclicBarrier barrier = new CyclicBarrier(THREADS);
+      List<Future<List<String>>> futures = Lists.newArrayList();
+      for (int t = 0; t < THREADS; t++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  barrier.await();
+                  return task.call();
+                }));
+      }
+
+      List<List<String>> results = Lists.newArrayList();
+      for (Future<List<String>> future : futures) {
+        try {
+          results.add(future.get(60, TimeUnit.SECONDS));
+        } catch (ExecutionException e) {
+          throw new AssertionError("Concurrent task failed", e.getCause());
+        }
+      }
+      return results;
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(value);
+    }
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) in.readObject();
+    }
+  }
+}


### PR DESCRIPTION
A single `StandardEncryptionManager` is shared across threads: it is cached per table (e.g. via `CachingCatalog`) and shipped to Spark executors inside `SerializableTable`, while commits mint keys into it and scan-planning / decryption threads read it. Its mutable `encryptionKeys` map (a `SerializableMap` over a plain `HashMap`) was accessed with no synchronization:

- `keyEncryptionKeyID()` / `addManifestListKeyMetadata()` are check-then-mint (reuse an unexpired key-encryption key, else create one). Two concurrent commits could each observe "no KEK" and mint a duplicate.
- `encryptionKeys()` / `encryptedByKey()` read the map while another thread `put()`s into it → `ConcurrentModificationException` and torn reads.
- Serialization for the executor broadcast traverses that same map with no lock, so a commit minting concurrently corrupts the stream.

## Change (scoped to this class; public API unchanged)

- `addManifestListKeyMetadata`, `keyEncryptionKeyID`, `encryptedByKey`, `encryptionKeys`, and the lazy `unwrappedKeyCache` are `synchronized` on the manager, so check-then-mint is atomic and reads never observe a partial map.
- `encryptionKeys()` returns an `ImmutableMap` copy taken under that lock.
- `writeObject` is `synchronized`, so serialization can't run mid-mint.

## Tests

`TestStandardEncryptionManagerConcurrency` — two bounded concurrency regressions:
- concurrent minting + reading yields unique, resolvable keys and exactly one key-encryption key;
- serializing while minting never corrupts the stream (fails without the `writeObject` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
