### PR TITLE
Core: Defensively copy TableMetadata.encryptionKeys to an immutable list

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -353,7 +353,7 @@ public class TableMetadata implements Serializable {
     this.snapshotsLoaded = snapshotsSupplier == null;
     this.snapshotLog = snapshotLog;
     this.previousFiles = previousFiles;
-    this.encryptionKeys = encryptionKeys;
+    this.encryptionKeys = ImmutableList.copyOf(encryptionKeys);
 
     // changes are carried through until metadata is read from a file
     this.changes = changes;


### PR DESCRIPTION
- **Problem:** `TableMetadata` is an immutable value object, but its constructor stores the caller-supplied `encryptionKeys` list *directly* and `encryptionKeys()` returns that same instance — so the collection can be mutated after the metadata is built, unlike the rest of `TableMetadata`'s state.
- **Precedent:** sibling collection fields in the *same* constructor already defensively copy — `statisticsFiles` and `partitionStatisticsFiles` use `ImmutableList.copyOf(...)`, and `snapshots` likewise. `encryptionKeys` is the lone outlier.
- **Fix:** copy it with `ImmutableList.copyOf(encryptionKeys)` (the field is already non-null-checked), bringing it in line and making the field truly immutable.
- One-line change; enables callers to treat a metadata's key set as a stable snapshot (e.g. deriving an encryption manager per metadata version).