### PR TITLE
Core, Hive: Commit manifest list encryption keys with the snapshot that uses them

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -46,8 +46,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptingFileIO;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.events.CreateSnapshotEvent;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.exceptions.CleanableFailure;
@@ -65,6 +68,7 @@ import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.Timer.Timed;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -114,6 +118,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private MetricsReporter reporter = LoggingMetricsReporter.instance();
   private volatile Long snapshotId = null;
   private TableMetadata base;
+  private List<EncryptedKey> manifestListKeys = ImmutableList.of();
   private boolean stageOnly = false;
   private Consumer<String> deleteFunc = defaultDelete;
   private SnapshotAncestryValidator snapshotAncestryValidator =
@@ -303,11 +308,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
     OutputFile manifestList = manifestListPath();
 
+    EncryptionManager encryption = ops.encryption();
     ManifestListWriter writer =
         ManifestLists.write(
             ops.current().formatVersion(),
             manifestList,
-            ops.encryption(),
+            encryption,
             snapshotId(),
             parentSnapshotId,
             sequenceNumber,
@@ -354,6 +360,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
           replacedRecords);
     }
 
+    String manifestListKeyId = writer.toManifestListFile().encryptionKeyID();
+    this.manifestListKeys = manifestListKeys(encryption, manifestListKeyId);
+
     return new BaseSnapshot(
         sequenceNumber,
         snapshotId(),
@@ -365,7 +374,29 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         manifestList.location(),
         nextRowId,
         assignedRows,
-        writer.toManifestListFile().encryptionKeyID());
+        manifestListKeyId);
+  }
+
+  /**
+   * The manifest list key and the key encryption key that wraps it, which must be committed
+   * alongside the snapshot that references them or the snapshot cannot be read.
+   */
+  private static List<EncryptedKey> manifestListKeys(EncryptionManager encryption, String keyId) {
+    if (keyId == null) {
+      return ImmutableList.of();
+    }
+
+    Map<String, EncryptedKey> keys = EncryptionUtil.encryptionKeys(encryption);
+    EncryptedKey manifestListKey = keys.get(keyId);
+    Preconditions.checkState(
+        manifestListKey != null, "Cannot find manifest list key metadata with id %s", keyId);
+    EncryptedKey keyEncryptionKey = keys.get(manifestListKey.encryptedById());
+    Preconditions.checkState(
+        keyEncryptionKey != null,
+        "Cannot find key encryption key with id %s",
+        manifestListKey.encryptedById());
+
+    return ImmutableList.of(manifestListKey, keyEncryptionKey);
   }
 
   private void runValidations(Snapshot parentSnapshot) {
@@ -493,16 +524,23 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             .countAttempts(commitMetrics().attempts())
             .run(
                 taskOps -> {
+                  // this attempt writes its own manifest list, so discard the keys of the last one
+                  this.manifestListKeys = ImmutableList.of();
                   Snapshot newSnapshot = apply();
                   newSnapshotId.set(newSnapshot.snapshotId());
                   TableMetadata.Builder update = TableMetadata.buildFrom(base);
                   if (base.snapshot(newSnapshot.snapshotId()) != null) {
                     // this is a rollback operation
                     update.setBranchSnapshot(newSnapshot.snapshotId(), targetBranch);
-                  } else if (stageOnly) {
-                    update.addSnapshot(newSnapshot);
                   } else {
-                    update.setBranchSnapshot(newSnapshot, targetBranch);
+                    // the new snapshot's manifest list is unreadable unless the keys that encrypt
+                    // it are committed with it
+                    manifestListKeys.forEach(update::addEncryptionKey);
+                    if (stageOnly) {
+                      update.addSnapshot(newSnapshot);
+                    } else {
+                      update.setBranchSnapshot(newSnapshot, targetBranch);
+                    }
                   }
 
                   TableMetadata updated = update.build();

--- a/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
@@ -24,7 +24,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.EncryptingFileIO;
@@ -51,47 +50,39 @@ class TestManifestListKeyPersistence {
   @TempDir private Path temp;
 
   @AfterEach
-  public void cleanup() {
+  void cleanup() {
     TestTables.clearTables();
   }
 
   @Test
-  void testCommittedSnapshotKeyIsInMetadata() {
+  void committedSnapshotKeyIsInMetadata() {
     TestTables.TestTable table = createEncryptedTable("mlk-basic");
-
-    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
-
-    Snapshot snapshot = table.currentSnapshot();
-    assertThat(snapshot.keyId()).as("manifest list should be encrypted").isNotNull();
-
-    assertThat(keyIds(table.ops().current()))
-        .as("committed metadata must contain the snapshot's manifest list key")
-        .contains(snapshot.keyId());
-  }
-
-  @Test
-  void testCommittedSnapshotIsReadableFromCommittedKeys() {
-    TestTables.TestTable table = createEncryptedTable("mlk-reload");
 
     table.newFastAppend().appendFile(TestBase.FILE_A).commit();
 
     TableMetadata committed = table.ops().current();
     Snapshot snapshot = table.currentSnapshot();
+    assertThat(snapshot.keyId()).as("manifest list should be encrypted").isNotNull();
 
-    // what a fresh reader does: build a manager from the committed key records alone
-    EncryptionManager reloaded =
-        EncryptionUtil.createEncryptionManager(
-            committed.encryptionKeys(), TABLE_PROPERTIES, kmsClient());
-
-    assertThat(
-            EncryptionUtil.decryptManifestListKeyMetadata(
-                new BaseManifestListFile(snapshot.manifestListLocation(), snapshot.keyId()),
-                reloaded))
-        .isNotNull();
+    EncryptedKey manifestListKey = key(committed, snapshot.keyId());
+    assertThat(manifestListKey).isNotNull();
+    assertThat(keyIds(committed))
+        .as("committed metadata must contain the snapshot's manifest list key")
+        .contains(snapshot.keyId(), manifestListKey.encryptedById());
   }
 
   @Test
-  void testStagedSnapshotKeyIsInMetadata() {
+  void committedSnapshotIsReadableFromCommittedKeys() {
+    TestTables.TestTable table = createEncryptedTable("mlk-reload");
+
+    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
+
+    TableMetadata committed = table.ops().current();
+    assertReadableFromCommittedKeys(committed, table.currentSnapshot());
+  }
+
+  @Test
+  void stagedSnapshotKeyIsInMetadata() {
     TestTables.TestTable table = createEncryptedTable("mlk-staged");
 
     table.newFastAppend().appendFile(TestBase.FILE_A).stageOnly().commit();
@@ -101,7 +92,7 @@ class TestManifestListKeyPersistence {
   }
 
   @Test
-  void testTransactionSnapshotKeysAreInMetadata() {
+  void transactionSnapshotKeysAreInMetadata() {
     TestTables.TestTable table = createEncryptedTable("mlk-transaction");
 
     Transaction transaction = table.newTransaction();
@@ -117,22 +108,20 @@ class TestManifestListKeyPersistence {
   }
 
   @Test
-  void testRetriedCommitPersistsOnlyTheCommittedSnapshotKeys() {
+  void retriedCommitPersistsReadableSnapshotKeys() {
     TestTables.TestTable table = createEncryptedTable("mlk-retry");
     ((TestTables.TestTableOperations) table.ops()).failCommits(2);
 
     table.newFastAppend().appendFile(TestBase.FILE_A).commit();
 
-    // three attempts minted three manifest list keys against one shared key encryption key
-    Set<String> generated = EncryptionUtil.encryptionKeys(table.ops().encryption()).keySet();
-    assertThat(generated).hasSize(4);
-
-    // only the committed attempt's two keys are persisted
     TableMetadata committed = table.ops().current();
+    Snapshot snapshot = table.currentSnapshot();
+    EncryptedKey manifestListKey = key(committed, snapshot.keyId());
+
+    assertThat(manifestListKey).isNotNull();
     assertThat(keyIds(committed))
-        .hasSize(2)
-        .contains(table.currentSnapshot().keyId())
-        .allMatch(generated::contains);
+        .containsExactlyInAnyOrder(snapshot.keyId(), manifestListKey.encryptedById());
+    assertReadableFromCommittedKeys(committed, snapshot);
   }
 
   private static KeyManagementClient kmsClient() {
@@ -143,6 +132,22 @@ class TestManifestListKeyPersistence {
 
   private static List<String> keyIds(TableMetadata metadata) {
     return metadata.encryptionKeys().stream().map(EncryptedKey::keyId).collect(Collectors.toList());
+  }
+
+  private static EncryptedKey key(TableMetadata metadata, String keyId) {
+    return metadata.encryptionKeys().stream()
+        .filter(key -> key.keyId().equals(keyId))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private static void assertReadableFromCommittedKeys(TableMetadata committed, Snapshot snapshot) {
+    EncryptionManager reloaded =
+        EncryptionUtil.createEncryptionManager(
+            committed.encryptionKeys(), TABLE_PROPERTIES, kmsClient());
+    EncryptingFileIO reloadedIO = EncryptingFileIO.combine(new TestTables.LocalFileIO(), reloaded);
+
+    assertThat(snapshot.allManifests(reloadedIO)).isNotEmpty();
   }
 
   private TestTables.TestTable createEncryptedTable(String name) {

--- a/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.iceberg.encryption.EncryptedKey;
+import org.apache.iceberg.encryption.EncryptingFileIO;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.EncryptionTestHelpers;
+import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.encryption.KeyManagementClient;
+import org.apache.iceberg.encryption.UnitestKMS;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * A snapshot with an encrypted manifest list can only be read if the key that encrypts it, and the
+ * key encryption key that wraps that key, are in the same table metadata.
+ */
+class TestManifestListKeyPersistence {
+
+  private static final Map<String, String> TABLE_PROPERTIES =
+      ImmutableMap.of(TableProperties.ENCRYPTION_TABLE_KEY, UnitestKMS.MASTER_KEY_NAME1);
+
+  @TempDir private Path temp;
+
+  @AfterEach
+  public void cleanup() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  void testCommittedSnapshotKeyIsInMetadata() {
+    TestTables.TestTable table = createEncryptedTable("mlk-basic");
+
+    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    assertThat(snapshot.keyId()).as("manifest list should be encrypted").isNotNull();
+
+    assertThat(keyIds(table.ops().current()))
+        .as("committed metadata must contain the snapshot's manifest list key")
+        .contains(snapshot.keyId());
+  }
+
+  @Test
+  void testCommittedSnapshotIsReadableFromCommittedKeys() {
+    TestTables.TestTable table = createEncryptedTable("mlk-reload");
+
+    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
+
+    TableMetadata committed = table.ops().current();
+    Snapshot snapshot = table.currentSnapshot();
+
+    // what a fresh reader does: build a manager from the committed key records alone
+    EncryptionManager reloaded =
+        EncryptionUtil.createEncryptionManager(
+            committed.encryptionKeys(), TABLE_PROPERTIES, kmsClient());
+
+    assertThat(
+            EncryptionUtil.decryptManifestListKeyMetadata(
+                new BaseManifestListFile(snapshot.manifestListLocation(), snapshot.keyId()),
+                reloaded))
+        .isNotNull();
+  }
+
+  @Test
+  void testStagedSnapshotKeyIsInMetadata() {
+    TestTables.TestTable table = createEncryptedTable("mlk-staged");
+
+    table.newFastAppend().appendFile(TestBase.FILE_A).stageOnly().commit();
+
+    Snapshot staged = Iterables.getOnlyElement(table.ops().current().snapshots());
+    assertThat(keyIds(table.ops().current())).contains(staged.keyId());
+  }
+
+  @Test
+  void testTransactionSnapshotKeysAreInMetadata() {
+    TestTables.TestTable table = createEncryptedTable("mlk-transaction");
+
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(TestBase.FILE_A).commit();
+    transaction.newFastAppend().appendFile(TestBase.FILE_B).commit();
+    transaction.commitTransaction();
+
+    TableMetadata committed = table.ops().current();
+    assertThat(committed.snapshots()).hasSize(2);
+    for (Snapshot snapshot : committed.snapshots()) {
+      assertThat(keyIds(committed)).contains(snapshot.keyId());
+    }
+  }
+
+  @Test
+  void testRetriedCommitPersistsOnlyTheCommittedSnapshotKeys() {
+    TestTables.TestTable table = createEncryptedTable("mlk-retry");
+    ((TestTables.TestTableOperations) table.ops()).failCommits(2);
+
+    table.newFastAppend().appendFile(TestBase.FILE_A).commit();
+
+    // three attempts minted three manifest list keys against one shared key encryption key
+    Set<String> generated = EncryptionUtil.encryptionKeys(table.ops().encryption()).keySet();
+    assertThat(generated).hasSize(4);
+
+    // only the committed attempt's two keys are persisted
+    TableMetadata committed = table.ops().current();
+    assertThat(keyIds(committed))
+        .hasSize(2)
+        .contains(table.currentSnapshot().keyId())
+        .allMatch(generated::contains);
+  }
+
+  private static KeyManagementClient kmsClient() {
+    return EncryptionUtil.createKmsClient(
+        ImmutableMap.of(
+            CatalogProperties.ENCRYPTION_KMS_IMPL, UnitestKMS.class.getCanonicalName()));
+  }
+
+  private static List<String> keyIds(TableMetadata metadata) {
+    return metadata.encryptionKeys().stream().map(EncryptedKey::keyId).collect(Collectors.toList());
+  }
+
+  private TestTables.TestTable createEncryptedTable(String name) {
+    EncryptionManager encryption = EncryptionTestHelpers.createEncryptionManager();
+    File dir = temp.resolve(name).toFile();
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations(
+            name, dir, EncryptingFileIO.combine(new TestTables.LocalFileIO(), encryption)) {
+          @Override
+          public EncryptionManager encryption() {
+            return encryption;
+          }
+        };
+
+    return TestTables.create(
+        dir, name, TestBase.SCHEMA, TestBase.SPEC, SortOrder.unsorted(), 3, ops);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -70,6 +70,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestCatalogUtil;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdatePartitionSpec;
@@ -80,6 +81,11 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptedKey;
+import org.apache.iceberg.encryption.EncryptingFileIO;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.EncryptionTestHelpers;
+import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -3117,6 +3123,86 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Table reloaded = catalog.loadTable(TABLE);
     assertThat(reloaded.currentSnapshot()).isNotNull();
     assertThat(reloaded.snapshot(expectedSnapshotId)).isNotNull();
+  }
+
+  @Test
+  void encryptedAppendSerializesManifestListKeys() throws IOException {
+    HeaderValidatingAdapter adapter =
+        Mockito.spy(
+            new HeaderValidatingAdapter(
+                backendCatalog, HTTPHeaders.of(Map.of()), HTTPHeaders.of(Map.of())));
+    EncryptionManager encryption = EncryptionTestHelpers.createEncryptionManager();
+
+    try (RESTCatalog catalog =
+        catalog(
+            adapter,
+            clientBuilder ->
+                new RESTSessionCatalog(clientBuilder, null) {
+                  @Override
+                  protected RESTTableOperations newTableOps(
+                      RESTClient restClient,
+                      String path,
+                      Supplier<Map<String, String>> readHeaders,
+                      Supplier<Map<String, String>> mutationHeaders,
+                      FileIO fileIO,
+                      TableMetadata current,
+                      Set<Endpoint> supportedEndpoints) {
+                    return new RESTTableOperations(
+                        restClient,
+                        path,
+                        readHeaders,
+                        mutationHeaders,
+                        EncryptingFileIO.combine(fileIO, encryption),
+                        current,
+                        supportedEndpoints) {
+                      @Override
+                      public EncryptionManager encryption() {
+                        return encryption;
+                      }
+                    };
+                  }
+                })) {
+      if (requiresNamespaceCreate()) {
+        catalog.createNamespace(TABLE.namespace());
+      }
+
+      Table table =
+          catalog
+              .buildTable(TABLE, SCHEMA)
+              .withProperty(TableProperties.FORMAT_VERSION, "3")
+              .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, UnitestKMS.MASTER_KEY_NAME1)
+              .create();
+      table.newFastAppend().appendFile(FILE_A).commit();
+
+      ArgumentCaptor<HTTPRequest> requestCaptor = ArgumentCaptor.forClass(HTTPRequest.class);
+      verify(adapter)
+          .handleRequest(
+              eq(Route.UPDATE_TABLE),
+              anyMap(),
+              requestCaptor.capture(),
+              eq(LoadTableResponse.class),
+              any());
+      assertThat(requestCaptor.getValue().body()).isInstanceOf(UpdateTableRequest.class);
+      UpdateTableRequest request = (UpdateTableRequest) requestCaptor.getValue().body();
+      List<MetadataUpdate.AddSnapshot> addedSnapshots =
+          request.updates().stream()
+              .filter(MetadataUpdate.AddSnapshot.class::isInstance)
+              .map(MetadataUpdate.AddSnapshot.class::cast)
+              .collect(Collectors.toList());
+      Map<String, EncryptedKey> keys =
+          request.updates().stream()
+              .filter(MetadataUpdate.AddEncryptionKey.class::isInstance)
+              .map(MetadataUpdate.AddEncryptionKey.class::cast)
+              .map(MetadataUpdate.AddEncryptionKey::key)
+              .collect(Collectors.toMap(EncryptedKey::keyId, Function.identity()));
+
+      assertThat(addedSnapshots).hasSize(1);
+      MetadataUpdate.AddSnapshot addSnapshot = addedSnapshots.get(0);
+      String manifestListKeyID = addSnapshot.snapshot().keyId();
+      assertThat(manifestListKeyID).isNotNull();
+      assertThat(keys).hasSize(2).containsKey(manifestListKeyID);
+      assertThat(keys).containsKey(keys.get(manifestListKeyID).encryptedById());
+    }
   }
 
   @Test

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
-import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -240,34 +239,18 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   @Override
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
     boolean newTable = base == null;
-    final TableMetadata tableMetadata;
     encryptionPropsFromMetadata(metadata.properties());
 
-    String newMetadataLocation;
-    EncryptionManager encrManager = encryption();
-    if (encrManager instanceof StandardEncryptionManager) {
-      // Add new encryption keys to the metadata
-      TableMetadata.Builder builder = TableMetadata.buildFrom(metadata);
-      for (Map.Entry<String, EncryptedKey> entry :
-          EncryptionUtil.encryptionKeys(encrManager).entrySet()) {
-        builder.addEncryptionKey(entry.getValue());
-      }
+    String newMetadataLocation = writeNewMetadataIfRequired(newTable, metadata);
 
-      tableMetadata = builder.build();
-    } else {
-      tableMetadata = metadata;
-    }
-
-    newMetadataLocation = writeNewMetadataIfRequired(newTable, tableMetadata);
-
-    boolean hiveEngineEnabled = hiveEngineEnabled(tableMetadata, conf);
+    boolean hiveEngineEnabled = hiveEngineEnabled(metadata, conf);
     boolean keepHiveStats = conf.getBoolean(ConfigProperties.KEEP_HIVE_STATS, false);
 
     BaseMetastoreOperations.CommitStatus commitStatus =
         BaseMetastoreOperations.CommitStatus.FAILURE;
     boolean updateHiveTable = false;
 
-    HiveLock lock = lockObject(base != null ? base : tableMetadata);
+    HiveLock lock = lockObject(base != null ? base : metadata);
     try {
       lock.lock();
 
@@ -291,14 +274,14 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       } else {
         tbl =
             newHmsTable(
-                tableMetadata.property(HiveCatalog.HMS_TABLE_OWNER, HiveHadoopUtil.currentUser()));
+                metadata.property(HiveCatalog.HMS_TABLE_OWNER, HiveHadoopUtil.currentUser()));
         LOG.debug("Committing new table: {}", fullName);
       }
 
       tbl.setSd(
           HiveOperationsBase.storageDescriptor(
-              tableMetadata.schema(),
-              tableMetadata.location(),
+              metadata.schema(),
+              metadata.location(),
               hiveEngineEnabled)); // set to pickup any schema changes
 
       String metadataLocation = tbl.getParameters().get(METADATA_LOCATION_PROP);
@@ -314,7 +297,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       if (base != null) {
         removedProps =
             base.properties().keySet().stream()
-                .filter(key -> !tableMetadata.properties().containsKey(key))
+                .filter(key -> !metadata.properties().containsKey(key))
                 .collect(Collectors.toSet());
 
         Preconditions.checkArgument(
@@ -331,7 +314,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       HMSTablePropertyHelper.updateHmsTableForIcebergTable(
           newMetadataLocation,
           tbl,
-          tableMetadata,
+          metadata,
           removedProps,
           hiveEngineEnabled,
           maxHiveTablePropertySize,
@@ -388,7 +371,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
           // issue for example, and triggers this exception. So we need double-check to make sure
           // this is really a concurrent modification. Hitting this exception means no pending
           // requests, if any, can succeed later, so it's safe to check status in strict mode
-          commitStatus = checkCommitStatusStrict(newMetadataLocation, tableMetadata);
+          commitStatus = checkCommitStatusStrict(newMetadataLocation, metadata);
           if (commitStatus == BaseMetastoreOperations.CommitStatus.FAILURE) {
             throw new CommitFailedException(
                 e, "The table %s.%s has been modified concurrently", database, tableName);
@@ -399,7 +382,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
               database,
               tableName,
               e);
-          commitStatus = checkCommitStatus(newMetadataLocation, tableMetadata);
+          commitStatus = checkCommitStatus(newMetadataLocation, metadata);
         }
 
         switch (commitStatus) {


### PR DESCRIPTION
Stacked on #22; base `sm/enc-1-manager-threadsafe-v2`.

The root defect is ownership, not concurrency. `ManifestListWriter` mints a key into mutable manager state while `SnapshotProducer` commits only its ID. A plain single-threaded `TableOperations` therefore commits an unreadable encrypted snapshot; concurrent refresh exposes the Hive workaround race.

`SnapshotProducer` now captures the exact manifest-list key and wrapping KEK from each attempt and adds them to the same `TableMetadata.Builder` branch as the new snapshot. Retry state is reset, rollback adds no keys, and the Hive copy-all block is removed. Public API is unchanged.

Tests cover committed, staged, transaction, and retry paths. Fresh managers built only from committed keys read the manifest list. A REST integration test captures the post-JSON-round-trip `UpdateTableRequest` and proves one `AddSnapshot` is accompanied by its linked MLK and KEK `AddEncryptionKey` updates.

Trade-off: selecting the pair uses the existing detached manager snapshot, repeating O(retained encryption keys) work already inherent in metadata persistence. A true O(1) lookup needs a new public core accessor or a broader mint-result API; this fix keeps the public API unchanged.

Validation: focused core persistence and REST tests; Hive compile; core/Hive Spotless. Staged transaction metadata is handled in #20. Supersedes #15.

---
**AI Disclosure**
- Model: Claude Opus 4.8; GPT-5
- Platform/Tool: Claude Code; OpenAI Codex
- Human Oversight: unreviewed
- Prompt Summary: Persist each encrypted manifest list MLK and KEK atomically with its snapshot and prove fresh-reader and REST behavior.
