### PR TITLE
Core, Hive: Resolve a staged snapshot's encryption keys from its own metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -235,27 +235,9 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
     return LocationProviders.locationsFor(current().location(), current().properties());
   }
 
-  /**
-   * Returns an {@link EncryptionManager} that can resolve the encryption keys of the given
-   * metadata, which may not be committed yet.
-   */
-  protected EncryptionManager encryption(TableMetadata metadata) {
-    return encryption();
-  }
-
-  /** Returns a {@link FileIO} that encrypts and decrypts using the given manager. */
-  protected FileIO io(EncryptionManager encryption) {
-    return io();
-  }
-
   @Override
   public TableOperations temp(TableMetadata uncommittedMetadata) {
     return new TableOperations() {
-      // built once and shared: each manager copies the metadata's keys and owns its own cache of
-      // keys unwrapped by the KMS
-      private EncryptionManager lazyEncryption = null;
-      private FileIO lazyIO = null;
-
       @Override
       public TableMetadata current() {
         return uncommittedMetadata;
@@ -285,21 +267,13 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
       }
 
       @Override
-      public synchronized FileIO io() {
-        if (lazyIO == null) {
-          this.lazyIO = BaseMetastoreTableOperations.this.io(encryption());
-        }
-
-        return lazyIO;
+      public FileIO io() {
+        return BaseMetastoreTableOperations.this.io();
       }
 
       @Override
-      public synchronized EncryptionManager encryption() {
-        if (lazyEncryption == null) {
-          this.lazyEncryption = BaseMetastoreTableOperations.this.encryption(uncommittedMetadata);
-        }
-
-        return lazyEncryption;
+      public EncryptionManager encryption() {
+        return BaseMetastoreTableOperations.this.encryption();
       }
 
       @Override

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -235,9 +235,27 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
     return LocationProviders.locationsFor(current().location(), current().properties());
   }
 
+  /**
+   * Returns an {@link EncryptionManager} that can resolve the encryption keys of the given
+   * metadata, which may not be committed yet.
+   */
+  protected EncryptionManager encryption(TableMetadata metadata) {
+    return encryption();
+  }
+
+  /** Returns a {@link FileIO} that encrypts and decrypts using the given manager. */
+  protected FileIO io(EncryptionManager encryption) {
+    return io();
+  }
+
   @Override
   public TableOperations temp(TableMetadata uncommittedMetadata) {
     return new TableOperations() {
+      // built once and shared: each manager copies the metadata's keys and owns its own cache of
+      // keys unwrapped by the KMS
+      private EncryptionManager lazyEncryption = null;
+      private FileIO lazyIO = null;
+
       @Override
       public TableMetadata current() {
         return uncommittedMetadata;
@@ -267,13 +285,21 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
       }
 
       @Override
-      public FileIO io() {
-        return BaseMetastoreTableOperations.this.io();
+      public synchronized FileIO io() {
+        if (lazyIO == null) {
+          this.lazyIO = BaseMetastoreTableOperations.this.io(encryption());
+        }
+
+        return lazyIO;
       }
 
       @Override
-      public EncryptionManager encryption() {
-        return BaseMetastoreTableOperations.this.encryption();
+      public synchronized EncryptionManager encryption() {
+        if (lazyEncryption == null) {
+          this.lazyEncryption = BaseMetastoreTableOperations.this.encryption(uncommittedMetadata);
+        }
+
+        return lazyEncryption;
       }
 
       @Override

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -66,7 +66,7 @@ public class BaseTransaction implements Transaction {
   private final String tableName;
   private final TableOperations ops;
   private final TransactionTable transactionTable;
-  private final TableOperations transactionOps;
+  private final TransactionTableOperations transactionOps;
   private final List<PendingUpdate> updates;
   private final Set<String> deletedFiles =
       Sets.newHashSet(); // keep track of files deleted in the most recent commit
@@ -445,6 +445,9 @@ public class BaseTransaction implements Transaction {
       // use refreshed the metadata
       this.base = underlyingOps.current();
       this.current = underlyingOps.current();
+      // the staged metadata the updates were applied to is gone, so anything derived from it -
+      // notably the encryption keys that resolve a snapshot's manifest list - must be rebuilt
+      transactionOps.resetTempOps();
       for (PendingUpdate update : updates) {
         // re-commit each update in the chain to apply it and update current
         try {
@@ -482,6 +485,10 @@ public class BaseTransaction implements Transaction {
 
   public class TransactionTableOperations implements TableOperations {
     private TableOperations tempOps = ops.temp(current);
+
+    private void resetTempOps() {
+      this.tempOps = ops.temp(current);
+    }
 
     @Override
     public TableMetadata current() {

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -445,8 +445,7 @@ public class BaseTransaction implements Transaction {
       // use refreshed the metadata
       this.base = underlyingOps.current();
       this.current = underlyingOps.current();
-      // the staged metadata the updates were applied to is gone, so anything derived from it -
-      // notably the encryption keys that resolve a snapshot's manifest list - must be rebuilt
+      // rebuild temporary operations against the refreshed metadata before replaying updates
       transactionOps.resetTempOps();
       for (PendingUpdate update : updates) {
         // re-commit each update in the chain to apply it and update current

--- a/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
@@ -32,6 +32,8 @@ import org.apache.iceberg.encryption.EncryptionTestHelpers;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.UnitestKMS;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.junit.jupiter.api.AfterEach;
@@ -124,6 +126,20 @@ class TestManifestListKeyPersistence {
     assertReadableFromCommittedKeys(committed, snapshot);
   }
 
+  @Test
+  void transactionRebaseUsesKeysFromRefreshedMetadata() {
+    TestTables.TestTable table = createMetadataScopedEncryptedTable("mlk-rebase");
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(TestBase.FILE_A).commit();
+
+    table.newFastAppend().appendFile(TestBase.FILE_B).commit();
+    transaction.commitTransaction();
+
+    TableMetadata committed = table.ops().current();
+    assertThat(committed.snapshots()).hasSize(2);
+    assertReadableFromCommittedKeys(committed, committed.currentSnapshot());
+  }
+
   private static KeyManagementClient kmsClient() {
     return EncryptionUtil.createKmsClient(
         ImmutableMap.of(
@@ -151,18 +167,84 @@ class TestManifestListKeyPersistence {
   }
 
   private TestTables.TestTable createEncryptedTable(String name) {
+    return createEncryptedTable(name, false);
+  }
+
+  private TestTables.TestTable createMetadataScopedEncryptedTable(String name) {
+    return createEncryptedTable(name, true);
+  }
+
+  private TestTables.TestTable createEncryptedTable(String name, boolean useMetadataScopedTemp) {
     EncryptionManager encryption = EncryptionTestHelpers.createEncryptionManager();
     File dir = temp.resolve(name).toFile();
+    FileIO plainFileIO = new TestTables.LocalFileIO();
     TestTables.TestTableOperations ops =
         new TestTables.TestTableOperations(
-            name, dir, EncryptingFileIO.combine(new TestTables.LocalFileIO(), encryption)) {
+            name, dir, EncryptingFileIO.combine(plainFileIO, encryption)) {
           @Override
           public EncryptionManager encryption() {
             return encryption;
+          }
+
+          @Override
+          public TableOperations temp(TableMetadata uncommittedMetadata) {
+            return useMetadataScopedTemp
+                ? metadataScopedTemp(this, uncommittedMetadata, plainFileIO)
+                : this;
           }
         };
 
     return TestTables.create(
         dir, name, TestBase.SCHEMA, TestBase.SPEC, SortOrder.unsorted(), 3, ops);
+  }
+
+  private static TableOperations metadataScopedTemp(
+      TableOperations outer, TableMetadata metadata, FileIO plainFileIO) {
+    EncryptionManager encryption =
+        EncryptionUtil.createEncryptionManager(
+            metadata.encryptionKeys(), TABLE_PROPERTIES, kmsClient());
+    FileIO encryptedFileIO = EncryptingFileIO.combine(plainFileIO, encryption);
+
+    return new TableOperations() {
+      @Override
+      public TableMetadata current() {
+        return metadata;
+      }
+
+      @Override
+      public TableMetadata refresh() {
+        throw new UnsupportedOperationException("Cannot refresh temporary table operations");
+      }
+
+      @Override
+      public void commit(TableMetadata base, TableMetadata updated) {
+        throw new UnsupportedOperationException("Cannot commit temporary table operations");
+      }
+
+      @Override
+      public FileIO io() {
+        return encryptedFileIO;
+      }
+
+      @Override
+      public EncryptionManager encryption() {
+        return encryption;
+      }
+
+      @Override
+      public String metadataFileLocation(String fileName) {
+        return outer.metadataFileLocation(fileName);
+      }
+
+      @Override
+      public LocationProvider locationProvider() {
+        return LocationProviders.locationsFor(metadata.location(), metadata.properties());
+      }
+
+      @Override
+      public long newSnapshotId() {
+        return outer.newSnapshotId();
+      }
+    };
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -36,7 +36,9 @@ import org.apache.iceberg.BaseMetastoreOperations;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ClientPool;
+import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.EncryptingFileIO;
@@ -44,7 +46,6 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
-import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -52,6 +53,7 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.ConfigProperties;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -135,36 +137,32 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   @Override
   public EncryptionManager encryption() {
     if (encryptionManager == null && tableKeyId != null) {
-      encryptionManager = createEncryptionManager(encryptedKeys);
+      encryptionManager = createEncryptionManager(encryptedKeys, tableKeyId, encryptionDekLength);
     }
 
     return encryptionManager != null ? encryptionManager : PlaintextEncryptionManager.instance();
   }
 
-  /**
-   * Uncommitted metadata carries keys that the committed table does not have yet, so a staged
-   * snapshot's manifest list is only readable through a manager built from that metadata.
-   */
-  @Override
-  protected EncryptionManager encryption(TableMetadata metadata) {
-    // a table created inside a transaction is not in the metastore yet, so its key id is only
-    // available from the uncommitted metadata
-    encryptionPropsFromMetadata(metadata.properties());
-    if (tableKeyId == null) {
+  private EncryptionManager encryptionFor(TableMetadata metadata) {
+    String encryptionKeyId =
+        tableKeyId != null
+            ? tableKeyId
+            : metadata.property(TableProperties.ENCRYPTION_TABLE_KEY, null);
+    if (encryptionKeyId == null) {
       return PlaintextEncryptionManager.instance();
     }
 
-    return createEncryptionManager(metadata.encryptionKeys());
+    int dataKeyLength =
+        encryptionDekLength > 0
+            ? encryptionDekLength
+            : metadata.propertyAsInt(
+                TableProperties.ENCRYPTION_DEK_LENGTH,
+                TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT);
+    return createEncryptionManager(metadata.encryptionKeys(), encryptionKeyId, dataKeyLength);
   }
 
-  @Override
-  protected FileIO io(EncryptionManager encryption) {
-    return encryption instanceof StandardEncryptionManager
-        ? EncryptingFileIO.combine(fileIO, encryption)
-        : fileIO;
-  }
-
-  private EncryptionManager createEncryptionManager(List<EncryptedKey> keys) {
+  private EncryptionManager createEncryptionManager(
+      List<EncryptedKey> keys, String encryptionKeyId, int dataKeyLength) {
     Preconditions.checkArgument(
         keyManagementClient != null,
         "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
@@ -173,9 +171,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
     Map<String, String> encryptionProperties =
         ImmutableMap.of(
             TableProperties.ENCRYPTION_TABLE_KEY,
-            tableKeyId,
+            encryptionKeyId,
             TableProperties.ENCRYPTION_DEK_LENGTH,
-            String.valueOf(encryptionDekLength));
+            String.valueOf(dataKeyLength));
 
     return EncryptionUtil.createEncryptionManager(keys, encryptionProperties, keyManagementClient);
   }
@@ -437,6 +435,59 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   @Override
   public ClientPool<IMetaStoreClient, TException> metaClients() {
     return metaClients;
+  }
+
+  @Override
+  public TableOperations temp(TableMetadata uncommittedMetadata) {
+    EncryptionManager tempEncryption = encryptionFor(uncommittedMetadata);
+    FileIO tempFileIO =
+        tempEncryption == PlaintextEncryptionManager.instance()
+            ? fileIO
+            : EncryptingFileIO.combine(fileIO, tempEncryption);
+
+    return new TableOperations() {
+      @Override
+      public TableMetadata current() {
+        return uncommittedMetadata;
+      }
+
+      @Override
+      public TableMetadata refresh() {
+        throw new UnsupportedOperationException(
+            "Cannot call refresh on temporary table operations");
+      }
+
+      @Override
+      public void commit(TableMetadata base, TableMetadata metadata) {
+        throw new UnsupportedOperationException("Cannot call commit on temporary table operations");
+      }
+
+      @Override
+      public String metadataFileLocation(String fileName) {
+        return HiveTableOperations.this.metadataFileLocation(uncommittedMetadata, fileName);
+      }
+
+      @Override
+      public LocationProvider locationProvider() {
+        return LocationProviders.locationsFor(
+            uncommittedMetadata.location(), uncommittedMetadata.properties());
+      }
+
+      @Override
+      public FileIO io() {
+        return tempFileIO;
+      }
+
+      @Override
+      public EncryptionManager encryption() {
+        return tempEncryption;
+      }
+
+      @Override
+      public long newSnapshotId() {
+        return HiveTableOperations.this.newSnapshotId();
+      }
+    };
   }
 
   /**

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -37,9 +36,7 @@ import org.apache.iceberg.BaseMetastoreOperations;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ClientPool;
-import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.EncryptingFileIO;
@@ -47,6 +44,7 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -54,11 +52,9 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.ConfigProperties;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -138,31 +134,50 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
   @Override
   public EncryptionManager encryption() {
-    if (encryptionManager != null) {
-      return encryptionManager;
+    if (encryptionManager == null && tableKeyId != null) {
+      encryptionManager = createEncryptionManager(encryptedKeys);
     }
 
-    if (tableKeyId != null) {
-      Preconditions.checkArgument(
-          keyManagementClient != null,
-          "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
-          CatalogProperties.ENCRYPTION_KMS_IMPL);
+    return encryptionManager != null ? encryptionManager : PlaintextEncryptionManager.instance();
+  }
 
-      Map<String, String> encryptionProperties =
-          ImmutableMap.of(
-              TableProperties.ENCRYPTION_TABLE_KEY,
-              tableKeyId,
-              TableProperties.ENCRYPTION_DEK_LENGTH,
-              String.valueOf(encryptionDekLength));
-
-      encryptionManager =
-          EncryptionUtil.createEncryptionManager(
-              encryptedKeys, encryptionProperties, keyManagementClient);
-    } else {
+  /**
+   * Uncommitted metadata carries keys that the committed table does not have yet, so a staged
+   * snapshot's manifest list is only readable through a manager built from that metadata.
+   */
+  @Override
+  protected EncryptionManager encryption(TableMetadata metadata) {
+    // a table created inside a transaction is not in the metastore yet, so its key id is only
+    // available from the uncommitted metadata
+    encryptionPropsFromMetadata(metadata.properties());
+    if (tableKeyId == null) {
       return PlaintextEncryptionManager.instance();
     }
 
-    return encryptionManager;
+    return createEncryptionManager(metadata.encryptionKeys());
+  }
+
+  @Override
+  protected FileIO io(EncryptionManager encryption) {
+    return encryption instanceof StandardEncryptionManager
+        ? EncryptingFileIO.combine(fileIO, encryption)
+        : fileIO;
+  }
+
+  private EncryptionManager createEncryptionManager(List<EncryptedKey> keys) {
+    Preconditions.checkArgument(
+        keyManagementClient != null,
+        "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
+        CatalogProperties.ENCRYPTION_KMS_IMPL);
+
+    Map<String, String> encryptionProperties =
+        ImmutableMap.of(
+            TableProperties.ENCRYPTION_TABLE_KEY,
+            tableKeyId,
+            TableProperties.ENCRYPTION_DEK_LENGTH,
+            String.valueOf(encryptionDekLength));
+
+    return EncryptionUtil.createEncryptionManager(keys, encryptionProperties, keyManagementClient);
   }
 
   @Override
@@ -213,23 +228,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
               ? Integer.parseInt(dekLengthFromHMS)
               : TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT;
 
-      encryptedKeys =
-          Optional.ofNullable(current().encryptionKeys())
-              .map(Lists::newLinkedList)
-              .orElseGet(Lists::newLinkedList);
+      encryptedKeys = current().encryptionKeys();
 
-      if (encryptionManager != null) {
-        Set<String> keyIdsFromMetadata =
-            encryptedKeys.stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
-
-        for (EncryptedKey keyFromEM : EncryptionUtil.encryptionKeys(encryptionManager).values()) {
-          if (!keyIdsFromMetadata.contains(keyFromEM.keyId())) {
-            encryptedKeys.add(keyFromEM);
-          }
-        }
-      }
-
-      // Force re-creation of encryption manager with updated keys
+      // re-create the encryption manager with the refreshed keys
       encryptingFileIO = null;
       encryptionManager = null;
     }
@@ -436,54 +437,6 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   @Override
   public ClientPool<IMetaStoreClient, TException> metaClients() {
     return metaClients;
-  }
-
-  @Override
-  public TableOperations temp(TableMetadata uncommittedMetadata) {
-    return new TableOperations() {
-      @Override
-      public TableMetadata current() {
-        return uncommittedMetadata;
-      }
-
-      @Override
-      public TableMetadata refresh() {
-        throw new UnsupportedOperationException(
-            "Cannot call refresh on temporary table operations");
-      }
-
-      @Override
-      public void commit(TableMetadata base, TableMetadata metadata) {
-        throw new UnsupportedOperationException("Cannot call commit on temporary table operations");
-      }
-
-      @Override
-      public String metadataFileLocation(String fileName) {
-        return HiveTableOperations.this.metadataFileLocation(uncommittedMetadata, fileName);
-      }
-
-      @Override
-      public LocationProvider locationProvider() {
-        return LocationProviders.locationsFor(
-            uncommittedMetadata.location(), uncommittedMetadata.properties());
-      }
-
-      @Override
-      public FileIO io() {
-        HiveTableOperations.this.encryptionPropsFromMetadata(uncommittedMetadata.properties());
-        return HiveTableOperations.this.io();
-      }
-
-      @Override
-      public EncryptionManager encryption() {
-        return HiveTableOperations.this.encryption();
-      }
-
-      @Override
-      public long newSnapshotId() {
-        return HiveTableOperations.this.newSnapshotId();
-      }
-    };
   }
 
   /**

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -19,6 +19,9 @@
 package org.apache.iceberg.spark.sql;
 
 import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -28,6 +31,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ChecksumFileSystem;
@@ -41,20 +46,24 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Tasks;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
 import org.junit.jupiter.api.AfterEach;
@@ -109,6 +118,76 @@ public class TestTableEncryption extends CatalogTestBase {
     return Streams.stream(table.newScan().planFiles())
         .map(FileScanTask::file)
         .collect(Collectors.toList());
+  }
+
+  private static List<FileScanTask> planSnapshot(Table table, long snapshotId) throws IOException {
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(snapshotId).planFiles()) {
+      return ImmutableList.copyOf(tasks);
+    }
+  }
+
+  @TestTemplate
+  public void testConcurrentAppendsPreserveEncryptionKeys() throws IOException {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    // a high retry ceiling so commits contending on one table lock do not exhaust retries
+    table
+        .updateProperties()
+        .set(COMMIT_NUM_RETRIES, "500")
+        .set(COMMIT_MIN_RETRY_WAIT_MS, "25")
+        .set(COMMIT_MAX_RETRY_WAIT_MS, "25")
+        .commit();
+
+    List<DataFile> initialFiles = currentDataFiles(table);
+    int initialSnapshotCount = (int) Streams.stream(table.snapshots()).count();
+    DataFile file = initialFiles.get(0);
+
+    int threadCount = 4;
+    int commitsPerThread = 40;
+    Tasks.range(threadCount)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(
+            MoreExecutors.getExitingExecutorService(
+                (ThreadPoolExecutor) Executors.newFixedThreadPool(threadCount)))
+        .run(
+            index -> {
+              for (int i = 0; i < commitsPerThread; i++) {
+                table.newFastAppend().appendFile(file).commit();
+              }
+            });
+
+    Table reloaded = validationCatalog.loadTable(tableIdent);
+    assertThat(reloaded.snapshots()).hasSize(initialSnapshotCount + threadCount * commitsPerThread);
+
+    // a snapshot that lost its manifest list key fails scan planning while decrypting it
+    for (Snapshot snapshot : reloaded.snapshots()) {
+      assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
+    }
+  }
+
+  @TestTemplate
+  public void testTransactionInterleavedWithDirectCommitOnSharedTable() throws IOException {
+    validationCatalog.initialize(catalogName, catalogConfig);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    DataFile file = currentDataFiles(table).get(0);
+
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(file).commit();
+
+    // a direct commit on the same instance lands between the transaction's operations
+    table.newFastAppend().appendFile(file).commit();
+
+    transaction.newFastAppend().appendFile(file).commit();
+    transaction.commitTransaction();
+
+    Table reloaded = validationCatalog.loadTable(tableIdent);
+    for (Snapshot snapshot : reloaded.snapshots()) {
+      assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
+    }
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -41,11 +41,13 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.UnitestKMS;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.parquet.Parquet;
@@ -109,6 +111,35 @@ public class TestTableEncryption extends CatalogTestBase {
     return Streams.stream(table.newScan().planFiles())
         .map(FileScanTask::file)
         .collect(Collectors.toList());
+  }
+
+  private static List<FileScanTask> planSnapshot(Table table, long snapshotId) throws IOException {
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(snapshotId).planFiles()) {
+      return ImmutableList.copyOf(tasks);
+    }
+  }
+
+  @TestTemplate
+  public void testTransactionInterleavedWithDirectCommitOnSharedTable() throws IOException {
+    validationCatalog.initialize(catalogName, catalogConfig);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    DataFile file = currentDataFiles(table).get(0);
+
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(file).commit();
+
+    // a direct commit on the same instance lands between the transaction's operations
+    table.newFastAppend().appendFile(file).commit();
+
+    transaction.newFastAppend().appendFile(file).commit();
+    transaction.commitTransaction();
+
+    Table reloaded = validationCatalog.loadTable(tableIdent);
+    for (Snapshot snapshot : reloaded.snapshots()) {
+      assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
+    }
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -121,7 +121,7 @@ public class TestTableEncryption extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testTransactionInterleavedWithDirectCommitOnSharedTable() throws IOException {
+  void transactionInterleavedWithDirectCommitPreservesEncryptionKeys() throws IOException {
     validationCatalog.initialize(catalogName, catalogConfig);
 
     Table table = validationCatalog.loadTable(tableIdent);
@@ -136,6 +136,7 @@ public class TestTableEncryption extends CatalogTestBase {
     transaction.newFastAppend().appendFile(file).commit();
     transaction.commitTransaction();
 
+    validationCatalog.invalidateTable(tableIdent);
     Table reloaded = validationCatalog.loadTable(tableIdent);
     for (Snapshot snapshot : reloaded.snapshots()) {
       assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();


### PR DESCRIPTION
Stacked on #19; base `sm/enc-2-core-key-persistence`.

Transactions read snapshots present only in staged metadata. Hive temporary operations previously delegated encryption to committed outer operations, so an interleaved direct commit could refresh away a staged key. Rebase replay also retained temporary operations for metadata that had just been replaced.

Hive `temp(uncommittedMetadata)` now builds one encryption manager and `EncryptingFileIO` from the metadata it represents. Existing-table key identity remains HMS-sourced. `BaseTransaction` rebuilds temporary operations after adopting refreshed metadata and before replay. With #19 owning persistence, the remaining Hive ambient-key merge is removed.

The design stays Hive-local: no new protected metastore hooks and no public API. A core test proves the rebase reset; Spark exercises staged operations, an interleaved direct commit, rebase, catalog invalidation, and fresh snapshot planning.

Validation: focused core persistence and REST tests; Spark 4.1 `TestTableEncryption`; Hive compile; module Spotless; `revapi`. A separate branch carries a 128-worker concurrent compaction workload with direct MLK/KEK assertions; three local runs passed.

Supersedes the transaction portions of #14 and #17 without breaking `StandardEncryptionManager` API.

---
**AI Disclosure**
- Model: Claude Opus 4.8; GPT-5
- Platform/Tool: Claude Code; OpenAI Codex
- Human Oversight: unreviewed
- Prompt Summary: Resolve staged encryption keys from transaction metadata and rebuild temporary operations before rebase replay.
