### PR TITLE
Hive: Fail the commit rather than write a snapshot whose manifest list key was lost

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -240,11 +240,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
   /** Validates that newly added snapshots retain the keys required to read their manifest lists. */
   private void checkManifestListKeysArePresent(TableMetadata metadata) {
-    Set<String> keyIds =
-        metadata.encryptionKeys().stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
-    Map<String, String> wrappedBy =
+    Map<String, EncryptedKey> keysById =
         metadata.encryptionKeys().stream()
-            .collect(Collectors.toMap(EncryptedKey::keyId, EncryptedKey::encryptedById));
+            .collect(Collectors.toMap(EncryptedKey::keyId, key -> key));
 
     for (MetadataUpdate change : metadata.changes()) {
       if (!(change instanceof MetadataUpdate.AddSnapshot addSnapshot)) {
@@ -261,14 +259,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
         continue;
       }
 
-      if (!keyIds.contains(keyId)) {
+      EncryptedKey manifestListKey = keysById.get(keyId);
+      if (manifestListKey == null) {
         throw new CommitFailedException(
             "Cannot commit snapshot %s to %s.%s: manifest list key %s is missing from table metadata",
             snapshot.snapshotId(), database, tableName, keyId);
       }
 
-      String keyEncryptionKeyId = wrappedBy.get(keyId);
-      if (!keyIds.contains(keyEncryptionKeyId)) {
+      String keyEncryptionKeyId = manifestListKey.encryptedById();
+      if (!keysById.containsKey(keyEncryptionKeyId)) {
         throw new CommitFailedException(
             "Cannot commit snapshot %s to %s.%s: key encryption key %s is missing from table metadata",
             snapshot.snapshotId(), database, tableName, keyEncryptionKeyId);

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -245,10 +245,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
             .collect(Collectors.toMap(EncryptedKey::keyId, key -> key));
 
     for (MetadataUpdate change : metadata.changes()) {
-      if (!(change instanceof MetadataUpdate.AddSnapshot addSnapshot)) {
+      if (!(change instanceof MetadataUpdate.AddSnapshot)) {
         continue;
       }
 
+      MetadataUpdate.AddSnapshot addSnapshot = (MetadataUpdate.AddSnapshot) change;
       Snapshot snapshot = addSnapshot.snapshot();
       if (metadata.snapshot(snapshot.snapshotId()) == null) {
         continue;

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -38,6 +38,8 @@ import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ClientPool;
 import org.apache.iceberg.LocationProviders;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
@@ -236,6 +238,47 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
     }
   }
 
+  /**
+   * A snapshot whose manifest list is encrypted is unreadable unless the manifest list key and the
+   * key encryption key that wraps it are in the same metadata. Keys are minted into the shared
+   * encryption manager while the manifest list is written and only copied into metadata here, so a
+   * concurrent refresh that replaces the manager in between drops them. Fail the commit instead of
+   * writing a snapshot that can never be decrypted; the retry re-writes the manifest list and
+   * usually succeeds.
+   */
+  private void checkManifestListKeysArePresent(TableMetadata metadata) {
+    Set<String> keyIds =
+        metadata.encryptionKeys().stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
+    Map<String, String> wrappedBy =
+        metadata.encryptionKeys().stream()
+            .collect(Collectors.toMap(EncryptedKey::keyId, EncryptedKey::encryptedById));
+
+    for (MetadataUpdate change : metadata.changes()) {
+      if (!(change instanceof MetadataUpdate.AddSnapshot)) {
+        continue;
+      }
+
+      Snapshot snapshot = ((MetadataUpdate.AddSnapshot) change).snapshot();
+      String keyId = snapshot.keyId();
+      if (keyId == null) {
+        continue;
+      }
+
+      if (!keyIds.contains(keyId)) {
+        throw new CommitFailedException(
+            "Cannot commit snapshot %s to %s.%s: manifest list key %s was lost by a concurrent refresh",
+            snapshot.snapshotId(), database, tableName, keyId);
+      }
+
+      String keyEncryptionKeyId = wrappedBy.get(keyId);
+      if (!keyIds.contains(keyEncryptionKeyId)) {
+        throw new CommitFailedException(
+            "Cannot commit snapshot %s to %s.%s: key encryption key %s was lost by a concurrent refresh",
+            snapshot.snapshotId(), database, tableName, keyEncryptionKeyId);
+      }
+    }
+  }
+
   @SuppressWarnings({"checkstyle:CyclomaticComplexity", "MethodLength"})
   @Override
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
@@ -254,6 +297,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       }
 
       tableMetadata = builder.build();
+      checkManifestListKeysArePresent(tableMetadata);
     } else {
       tableMetadata = metadata;
     }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -238,14 +238,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
     }
   }
 
-  /**
-   * A snapshot whose manifest list is encrypted is unreadable unless the manifest list key and the
-   * key encryption key that wraps it are in the same metadata. Keys are minted into the shared
-   * encryption manager while the manifest list is written and only copied into metadata here, so a
-   * concurrent refresh that replaces the manager in between drops them. Fail the commit instead of
-   * writing a snapshot that can never be decrypted; the retry re-writes the manifest list and
-   * usually succeeds.
-   */
+  /** Validates that newly added snapshots retain the keys required to read their manifest lists. */
   private void checkManifestListKeysArePresent(TableMetadata metadata) {
     Set<String> keyIds =
         metadata.encryptionKeys().stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
@@ -254,11 +247,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
             .collect(Collectors.toMap(EncryptedKey::keyId, EncryptedKey::encryptedById));
 
     for (MetadataUpdate change : metadata.changes()) {
-      if (!(change instanceof MetadataUpdate.AddSnapshot)) {
+      if (!(change instanceof MetadataUpdate.AddSnapshot addSnapshot)) {
         continue;
       }
 
-      Snapshot snapshot = ((MetadataUpdate.AddSnapshot) change).snapshot();
+      Snapshot snapshot = addSnapshot.snapshot();
+      if (metadata.snapshot(snapshot.snapshotId()) == null) {
+        continue;
+      }
+
       String keyId = snapshot.keyId();
       if (keyId == null) {
         continue;
@@ -266,14 +263,14 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
       if (!keyIds.contains(keyId)) {
         throw new CommitFailedException(
-            "Cannot commit snapshot %s to %s.%s: manifest list key %s was lost by a concurrent refresh",
+            "Cannot commit snapshot %s to %s.%s: manifest list key %s is missing from table metadata",
             snapshot.snapshotId(), database, tableName, keyId);
       }
 
       String keyEncryptionKeyId = wrappedBy.get(keyId);
       if (!keyIds.contains(keyEncryptionKeyId)) {
         throw new CommitFailedException(
-            "Cannot commit snapshot %s to %s.%s: key encryption key %s was lost by a concurrent refresh",
+            "Cannot commit snapshot %s to %s.%s: key encryption key %s is missing from table metadata",
             snapshot.snapshotId(), database, tableName, keyEncryptionKeyId);
       }
     }
@@ -297,11 +294,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       }
 
       tableMetadata = builder.build();
-      checkManifestListKeysArePresent(tableMetadata);
     } else {
       tableMetadata = metadata;
     }
 
+    checkManifestListKeysArePresent(tableMetadata);
     newMetadataLocation = writeNewMetadataIfRequired(newTable, tableMetadata);
 
     boolean hiveEngineEnabled = hiveEngineEnabled(tableMetadata, conf);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -28,16 +28,24 @@ import static org.mockito.Mockito.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.BaseEncryptedKey;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -52,6 +60,70 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.junit.platform.commons.support.ReflectionSupport;
 
 public class TestHiveCommits extends HiveTableTestBase {
+
+  @Test
+  void rejectsMissingManifestListKeyBeforePersisting() throws TException, InterruptedException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+    TableMetadata base = ops.current();
+    int metadataFiles = metadataFileCount(base);
+    Snapshot snapshot = snapshotWithKey(base, "missing-mlk");
+    TableMetadata updated = TableMetadata.buildFrom(base).addSnapshot(snapshot).build();
+    HiveTableOperations spyOps = spy(ops);
+
+    assertThatThrownBy(() -> spyOps.commit(base, updated))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage(
+            "Cannot commit snapshot %s to %s.%s: manifest list key missing-mlk is missing from table metadata",
+            snapshot.snapshotId(), TABLE_IDENTIFIER.namespace(), TABLE_IDENTIFIER.name());
+
+    verify(spyOps, never()).persistTable(any(), anyBoolean(), any());
+    assertThat(metadataFileCount(base)).isEqualTo(metadataFiles);
+    assertThat(ops.refresh().metadataFileLocation()).isEqualTo(base.metadataFileLocation());
+  }
+
+  @Test
+  void rejectsMissingKeyEncryptionKeyBeforePersisting() throws TException, InterruptedException {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+    TableMetadata base = ops.current();
+    int metadataFiles = metadataFileCount(base);
+    Snapshot snapshot = snapshotWithKey(base, "mlk");
+    TableMetadata updated =
+        TableMetadata.buildFrom(base)
+            .addEncryptionKey(
+                new BaseEncryptedKey("mlk", ByteBuffer.wrap(new byte[16]), "missing-kek", Map.of()))
+            .addSnapshot(snapshot)
+            .build();
+    HiveTableOperations spyOps = spy(ops);
+
+    assertThatThrownBy(() -> spyOps.commit(base, updated))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage(
+            "Cannot commit snapshot %s to %s.%s: key encryption key missing-kek is missing from table metadata",
+            snapshot.snapshotId(), TABLE_IDENTIFIER.namespace(), TABLE_IDENTIFIER.name());
+
+    verify(spyOps, never()).persistTable(any(), anyBoolean(), any());
+    assertThat(metadataFileCount(base)).isEqualTo(metadataFiles);
+    assertThat(ops.refresh().metadataFileLocation()).isEqualTo(base.metadataFileLocation());
+  }
+
+  @Test
+  void ignoresAddedSnapshotRemovedFromFinalMetadata() {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+    TableMetadata base = ops.current();
+    Snapshot snapshot = snapshotWithKey(base, "missing-mlk");
+    TableMetadata updated =
+        TableMetadata.buildFrom(base)
+            .addSnapshot(snapshot)
+            .removeSnapshots(List.of(snapshot.snapshotId()))
+            .build();
+
+    ops.commit(base, updated);
+
+    assertThat(ops.refresh().snapshot(snapshot.snapshotId())).isNull();
+  }
 
   @Test
   public void testSuppressUnlockExceptions() {
@@ -617,5 +689,13 @@ public class TestHiveCommits extends HiveTableTestBase {
         .getParentFile()
         .listFiles(file -> file.getName().endsWith("metadata.json"))
         .length;
+  }
+
+  private static Snapshot snapshotWithKey(TableMetadata base, String keyId) {
+    Snapshot snapshot = mock(Snapshot.class);
+    when(snapshot.snapshotId()).thenReturn(100L);
+    when(snapshot.sequenceNumber()).thenReturn(base.nextSequenceNumber());
+    when(snapshot.keyId()).thenReturn(keyId);
+    return snapshot;
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -126,6 +126,24 @@ public class TestHiveCommits extends HiveTableTestBase {
   }
 
   @Test
+  void ignoresUnreferencedKeyWithoutWrappingKey() {
+    Table table = catalog.loadTable(TABLE_IDENTIFIER);
+    HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();
+    TableMetadata base = ops.current();
+    TableMetadata updated =
+        TableMetadata.buildFrom(base)
+            .addEncryptionKey(
+                new BaseEncryptedKey("unreferenced", ByteBuffer.wrap(new byte[16]), null, Map.of()))
+            .build();
+
+    ops.commit(base, updated);
+
+    assertThat(ops.refresh().encryptionKeys())
+        .extracting(key -> key.keyId())
+        .containsExactly("unreferenced");
+  }
+
+  @Test
   public void testSuppressUnlockExceptions() {
     Table table = catalog.loadTable(TABLE_IDENTIFIER);
     HiveTableOperations ops = (HiveTableOperations) ((HasTableOperations) table).operations();

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -713,6 +713,7 @@ public class TestHiveCommits extends HiveTableTestBase {
     Snapshot snapshot = mock(Snapshot.class);
     when(snapshot.snapshotId()).thenReturn(100L);
     when(snapshot.sequenceNumber()).thenReturn(base.nextSequenceNumber());
+    when(snapshot.timestampMillis()).thenReturn(base.lastUpdatedMillis() + 1);
     when(snapshot.keyId()).thenReturn(keyId);
     return snapshot;
   }


### PR DESCRIPTION
Standalone fail-closed containment, independent of the proposed core fix.

An encrypted snapshot is permanently unreadable if its manifest-list key or wrapping key-encryption key is absent from table metadata. Hive currently copies keys from shared manager state during commit, and a refresh can replace that manager after a writer captured it.

Before writing a metadata file, this change validates final metadata for newly added snapshots that still survive. Missing keys raise `CommitFailedException`. Historical and removed snapshots are not revalidated, unrelated custom keys are ignored, and validation is independent of manager type. Direct commits may retry; transactions are guaranteed to fail closed.

Validation:
- `:iceberg-hive-metastore:test --tests org.apache.iceberg.hive.TestHiveCommits`
- `:iceberg-hive-metastore:spotlessCheck`

---
**AI Disclosure**
- Model: Claude Opus 4.8; GPT-5
- Platform/Tool: Claude Code; OpenAI Codex
- Human Oversight: unreviewed
- Prompt Summary: Contain manifest-list encryption key loss and add commit-path regression coverage.
