### PR TITLE
Core: Make StandardEncryptionManager thread-safe

### DIFF
--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
@@ -148,14 +148,12 @@ public class EncryptionUtil {
         "Snapshot key metadata encryption requires a StandardEncryptionManager");
     StandardEncryptionManager sem = (StandardEncryptionManager) em;
     String manifestListKeyId = manifestList.encryptionKeyID();
-    Map<String, EncryptedKey> encryptionKeys = sem.encryptionKeys();
-    EncryptedKey manifestListKey = encryptionKeys.get(manifestListKeyId);
+    EncryptedKey manifestListKey = sem.encryptionKey(manifestListKeyId);
     ByteBuffer encryptedKeyMetadata = manifestListKey.encryptedKeyMetadata();
     String keyEncryptionKeyID = manifestListKey.encryptedById();
     ByteBuffer keyEncryptionKey = sem.encryptedByKey(manifestListKeyId);
     String keyEncryptionKeyTimestamp =
-        encryptionKeys
-            .get(keyEncryptionKeyID)
+        sem.encryptionKey(keyEncryptionKeyID)
             .properties()
             .get(StandardEncryptionManager.KEY_TIMESTAMP);
     Preconditions.checkState(

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -161,7 +161,23 @@ public class StandardEncryptionManager implements EncryptionManager {
   }
 
   synchronized Map<String, EncryptedKey> encryptionKeys() {
-    return ImmutableMap.copyOf(encryptionKeys);
+    ImmutableMap.Builder<String, EncryptedKey> snapshot =
+        ImmutableMap.builderWithExpectedSize(encryptionKeys.size());
+    for (EncryptedKey key : encryptionKeys.values()) {
+      snapshot.put(
+          key.keyId(),
+          new BaseEncryptedKey(
+              key.keyId(),
+              ByteBuffers.copy(key.encryptedKeyMetadata()),
+              key.encryptedById(),
+              key.properties()));
+    }
+
+    return snapshot.build();
+  }
+
+  synchronized EncryptedKey encryptionKey(String keyId) {
+    return encryptionKeys.get(keyId);
   }
 
   synchronized String keyEncryptionKeyID() {

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -93,7 +93,10 @@ public class StandardEncryptionManager implements EncryptionManager {
         this.encryptionKeys.put(
             key.keyId(),
             new BaseEncryptedKey(
-                key.keyId(), key.encryptedKeyMetadata(), key.encryptedById(), key.properties()));
+                key.keyId(),
+                ByteBuffers.copy(key.encryptedKeyMetadata()),
+                key.encryptedById(),
+                key.properties()));
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.encryption;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Base64;
@@ -31,6 +33,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.ByteBuffers;
@@ -95,6 +98,10 @@ public class StandardEncryptionManager implements EncryptionManager {
     }
   }
 
+  private synchronized void writeObject(ObjectOutputStream out) throws IOException {
+    out.defaultWriteObject();
+  }
+
   @Override
   public NativeEncryptionOutputFile encrypt(OutputFile plainOutput) {
     return new StandardEncryptedOutputFile(plainOutput, dataKeyLength);
@@ -115,7 +122,7 @@ public class StandardEncryptionManager implements EncryptionManager {
     return Iterables.transform(encrypted, this::decrypt);
   }
 
-  private LoadingCache<String, ByteBuffer> unwrappedKeyCache() {
+  private synchronized LoadingCache<String, ByteBuffer> unwrappedKeyCache() {
     if (this.unwrappedKeyCache == null) {
       this.unwrappedKeyCache =
           Caffeine.newBuilder()
@@ -153,11 +160,11 @@ public class StandardEncryptionManager implements EncryptionManager {
     return kmsClient.unwrapKey(wrappedSecretKey, tableKeyId);
   }
 
-  Map<String, EncryptedKey> encryptionKeys() {
-    return encryptionKeys;
+  synchronized Map<String, EncryptedKey> encryptionKeys() {
+    return ImmutableMap.copyOf(encryptionKeys);
   }
 
-  String keyEncryptionKeyID() {
+  synchronized String keyEncryptionKeyID() {
     // Find unexpired key encryption key
     for (String keyID : encryptionKeys.keySet()) {
       EncryptedKey key = encryptionKeys.get(keyID);
@@ -193,7 +200,7 @@ public class StandardEncryptionManager implements EncryptionManager {
     return System.currentTimeMillis() + testTimeShift;
   }
 
-  ByteBuffer encryptedByKey(String manifestListKeyID) {
+  synchronized ByteBuffer encryptedByKey(String manifestListKeyID) {
     EncryptedKey encryptedKeyMetadata = encryptionKeys.get(manifestListKeyID);
 
     Preconditions.checkState(
@@ -209,7 +216,7 @@ public class StandardEncryptionManager implements EncryptionManager {
     return unwrappedKeyCache().get(encryptedKeyMetadata.encryptedById());
   }
 
-  public String addManifestListKeyMetadata(NativeEncryptionKeyMetadata keyMetadata) {
+  public synchronized String addManifestListKeyMetadata(NativeEncryptionKeyMetadata keyMetadata) {
     String manifestListKeyID = generateKeyId();
     String keyEncryptionKeyID = keyEncryptionKeyID();
     String keyEncryptionKeyTimestamp =

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.encryption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+public class TestStandardEncryptionManagerConcurrency {
+
+  private static final int THREADS = 4;
+  private static final int KEYS_PER_THREAD = 50;
+  private static final int ROUNDS = 300;
+
+  @Test
+  public void testConcurrentMintingIsThreadSafe() throws Exception {
+    StandardEncryptionManager manager = newManager();
+
+    List<String> keyIds = Lists.newArrayList();
+    for (List<String> perThread :
+        runConcurrently(
+            () -> {
+              List<String> ids = Lists.newArrayList();
+              for (int i = 0; i < KEYS_PER_THREAD; i++) {
+                ids.add(manager.addManifestListKeyMetadata(keyMetadata()));
+                manager.encryptionKeys().forEach((id, key) -> {}); // concurrent read must not throw
+              }
+              return ids;
+            })) {
+      keyIds.addAll(perThread);
+    }
+
+    // No lost updates or duplicate ids under concurrency, and every minted key resolves.
+    assertThat(Set.copyOf(keyIds)).hasSize(THREADS * KEYS_PER_THREAD);
+    for (String keyId : keyIds) {
+      assertThat(manager.encryptedByKey(keyId)).isNotNull();
+    }
+
+    // keyEncryptionKeyID()'s check-then-mint is atomic: exactly one key encryption key is created.
+    long kekCount =
+        manager.encryptionKeys().values().stream()
+            .filter(key -> key.encryptedById().equals(UnitestKMS.MASTER_KEY_NAME1))
+            .count();
+    assertThat(kekCount).isEqualTo(1L);
+  }
+
+  @Test
+  public void testConcurrentSerializationWhileMintingStaysConsistent() throws Exception {
+    StandardEncryptionManager manager = newManager();
+    List<String> seeded = Lists.newArrayList();
+    for (int i = 0; i < 10; i++) {
+      seeded.add(manager.addManifestListKeyMetadata(keyMetadata()));
+    }
+
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    CountDownLatch start = new CountDownLatch(1);
+    Thread minter =
+        new Thread(
+            () -> {
+              try {
+                start.await();
+                for (int i = 0; i < ROUNDS; i++) {
+                  manager.addManifestListKeyMetadata(keyMetadata());
+                }
+              } catch (Throwable t) {
+                failure.compareAndSet(null, t);
+              }
+            });
+
+    minter.start();
+    start.countDown();
+    // writeObject is synchronized, so serialization never traverses the key map mid-put: every
+    // round trip is a complete, still-functional snapshot rather than a corrupt stream.
+    for (int i = 0; i < ROUNDS; i++) {
+      assertThat(roundTrip(manager).encryptionKeys().keySet()).containsAll(seeded);
+    }
+    minter.join(TimeUnit.SECONDS.toMillis(30));
+
+    assertThat(minter.isAlive()).isFalse();
+    assertThat(failure.get()).isNull();
+  }
+
+  private static StandardEncryptionManager newManager() {
+    return (StandardEncryptionManager) EncryptionTestHelpers.createEncryptionManager();
+  }
+
+  private static NativeEncryptionKeyMetadata keyMetadata() {
+    return new StandardKeyMetadata(new byte[16], new byte[16]);
+  }
+
+  private static List<List<String>> runConcurrently(Callable<List<String>> task) throws Exception {
+    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+    try {
+      CyclicBarrier barrier = new CyclicBarrier(THREADS);
+      List<Future<List<String>>> futures = Lists.newArrayList();
+      for (int t = 0; t < THREADS; t++) {
+        futures.add(
+            pool.submit(
+                () -> {
+                  barrier.await();
+                  return task.call();
+                }));
+      }
+
+      List<List<String>> results = Lists.newArrayList();
+      for (Future<List<String>> future : futures) {
+        try {
+          results.add(future.get(60, TimeUnit.SECONDS));
+        } catch (ExecutionException e) {
+          throw new AssertionError("Concurrent task failed", e.getCause());
+        }
+      }
+      return results;
+    } finally {
+      pool.shutdownNow();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(value);
+    }
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) in.readObject();
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -19,133 +19,156 @@
 package org.apache.iceberg.encryption;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Callable;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.CyclicBarrier;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
-public class TestStandardEncryptionManagerConcurrency {
+class TestStandardEncryptionManagerConcurrency {
 
-  private static final int THREADS = 4;
-  private static final int KEYS_PER_THREAD = 50;
-  private static final int ROUNDS = 300;
+  private static final long WAIT_SECONDS = 10;
 
   @Test
-  public void testConcurrentMintingIsThreadSafe() throws Exception {
-    StandardEncryptionManager manager = newManager();
-
-    List<String> keyIds = Lists.newArrayList();
-    for (List<String> perThread :
-        runConcurrently(
+  void concurrentMintingCreatesOneKeyEncryptionKey() throws Exception {
+    BlockingKms kms = new BlockingKms();
+    StandardEncryptionManager manager = newManager(kms);
+    AtomicReference<String> firstKey = new AtomicReference<>();
+    AtomicReference<String> secondKey = new AtomicReference<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    CountDownLatch secondStarted = new CountDownLatch(1);
+    Thread first =
+        new Thread(
+            () ->
+                capture(
+                    () -> firstKey.set(manager.addManifestListKeyMetadata(keyMetadata())),
+                    failure));
+    Thread second =
+        new Thread(
             () -> {
-              List<String> ids = Lists.newArrayList();
-              for (int i = 0; i < KEYS_PER_THREAD; i++) {
-                ids.add(manager.addManifestListKeyMetadata(keyMetadata()));
-                manager.encryptionKeys().forEach((id, key) -> {}); // concurrent read must not throw
-              }
-              return ids;
-            })) {
-      keyIds.addAll(perThread);
+              secondStarted.countDown();
+              capture(
+                  () -> secondKey.set(manager.addManifestListKeyMetadata(keyMetadata())), failure);
+            });
+
+    first.start();
+    kms.awaitWrap();
+    second.start();
+    assertThat(secondStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+
+    try {
+      awaitBlocked(second);
+      assertThat(kms.wrapCalls()).isEqualTo(1);
+    } finally {
+      kms.releaseWrap();
+      join(first);
+      join(second);
     }
 
-    // No lost updates or duplicate ids under concurrency, and every minted key resolves.
-    assertThat(Set.copyOf(keyIds)).hasSize(THREADS * KEYS_PER_THREAD);
-    for (String keyId : keyIds) {
-      assertThat(manager.encryptedByKey(keyId)).isNotNull();
-    }
-
-    // keyEncryptionKeyID()'s check-then-mint is atomic: exactly one key encryption key is created.
-    long kekCount =
-        manager.encryptionKeys().values().stream()
-            .filter(key -> key.encryptedById().equals(UnitestKMS.MASTER_KEY_NAME1))
-            .count();
-    assertThat(kekCount).isEqualTo(1L);
+    assertThat(failure.get()).isNull();
+    assertThat(manager.encryptionKeys()).containsKeys(firstKey.get(), secondKey.get()).hasSize(3);
+    assertThat(
+            manager.encryptionKeys().values().stream()
+                .filter(key -> UnitestKMS.MASTER_KEY_NAME1.equals(key.encryptedById()))
+                .count())
+        .isEqualTo(1L);
   }
 
   @Test
-  public void testConcurrentSerializationWhileMintingStaysConsistent() throws Exception {
-    StandardEncryptionManager manager = newManager();
-    List<String> seeded = Lists.newArrayList();
-    for (int i = 0; i < 10; i++) {
-      seeded.add(manager.addManifestListKeyMetadata(keyMetadata()));
-    }
-
+  void serializationWaitsForCompleteKeyMint() throws Exception {
+    BlockingKms kms = new BlockingKms();
+    StandardEncryptionManager manager = newManager(kms);
+    AtomicReference<String> keyId = new AtomicReference<>();
+    AtomicReference<StandardEncryptionManager> serialized = new AtomicReference<>();
     AtomicReference<Throwable> failure = new AtomicReference<>();
-    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch serializationStarted = new CountDownLatch(1);
     Thread minter =
         new Thread(
+            () ->
+                capture(
+                    () -> keyId.set(manager.addManifestListKeyMetadata(keyMetadata())), failure));
+    Thread serializer =
+        new Thread(
             () -> {
-              try {
-                start.await();
-                for (int i = 0; i < ROUNDS; i++) {
-                  manager.addManifestListKeyMetadata(keyMetadata());
-                }
-              } catch (Throwable t) {
-                failure.compareAndSet(null, t);
-              }
+              serializationStarted.countDown();
+              capture(() -> serialized.set(roundTrip(manager)), failure);
             });
 
     minter.start();
-    start.countDown();
-    // writeObject is synchronized, so serialization never traverses the key map mid-put: every
-    // round trip is a complete, still-functional snapshot rather than a corrupt stream.
-    for (int i = 0; i < ROUNDS; i++) {
-      assertThat(roundTrip(manager).encryptionKeys().keySet()).containsAll(seeded);
-    }
-    minter.join(TimeUnit.SECONDS.toMillis(30));
+    kms.awaitWrap();
+    serializer.start();
+    assertThat(serializationStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
 
-    assertThat(minter.isAlive()).isFalse();
+    try {
+      awaitBlocked(serializer);
+      assertThat(serialized.get()).isNull();
+    } finally {
+      kms.releaseWrap();
+      join(minter);
+      join(serializer);
+    }
+
     assertThat(failure.get()).isNull();
+    EncryptedKey manifestListKey = serialized.get().encryptionKeys().get(keyId.get());
+    assertThat(manifestListKey).isNotNull();
+    assertThat(serialized.get().encryptionKeys())
+        .containsKey(manifestListKey.encryptedById())
+        .hasSize(2);
+    assertThat(serialized.get().encryptedByKey(keyId.get())).isNotNull();
   }
 
-  private static StandardEncryptionManager newManager() {
-    return (StandardEncryptionManager) EncryptionTestHelpers.createEncryptionManager();
+  @Test
+  void encryptionKeysReturnsImmutableSnapshot() {
+    StandardEncryptionManager manager = newManager(new UnitestKMS());
+    String firstKey = manager.addManifestListKeyMetadata(keyMetadata());
+    Map<String, EncryptedKey> snapshot = manager.encryptionKeys();
+
+    String secondKey = manager.addManifestListKeyMetadata(keyMetadata());
+
+    assertThat(snapshot).containsKey(firstKey).doesNotContainKey(secondKey).hasSize(2);
+    assertThatThrownBy(snapshot::clear).isInstanceOf(UnsupportedOperationException.class);
+  }
+
+  private static StandardEncryptionManager newManager(UnitestKMS kms) {
+    kms.initialize(Map.of());
+    return new StandardEncryptionManager(List.of(), UnitestKMS.MASTER_KEY_NAME1, 16, kms);
   }
 
   private static NativeEncryptionKeyMetadata keyMetadata() {
     return new StandardKeyMetadata(new byte[16], new byte[16]);
   }
 
-  private static List<List<String>> runConcurrently(Callable<List<String>> task) throws Exception {
-    ExecutorService pool = Executors.newFixedThreadPool(THREADS);
+  private static void capture(ThrowingRunnable action, AtomicReference<Throwable> failure) {
     try {
-      CyclicBarrier barrier = new CyclicBarrier(THREADS);
-      List<Future<List<String>>> futures = Lists.newArrayList();
-      for (int t = 0; t < THREADS; t++) {
-        futures.add(
-            pool.submit(
-                () -> {
-                  barrier.await();
-                  return task.call();
-                }));
-      }
-
-      List<List<String>> results = Lists.newArrayList();
-      for (Future<List<String>> future : futures) {
-        try {
-          results.add(future.get(60, TimeUnit.SECONDS));
-        } catch (ExecutionException e) {
-          throw new AssertionError("Concurrent task failed", e.getCause());
-        }
-      }
-      return results;
-    } finally {
-      pool.shutdownNow();
+      action.run();
+    } catch (Throwable t) {
+      failure.compareAndSet(null, t);
     }
+  }
+
+  private static void awaitBlocked(Thread thread) {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(WAIT_SECONDS);
+    while (thread.isAlive()
+        && thread.getState() != Thread.State.BLOCKED
+        && System.nanoTime() < deadline) {
+      Thread.yield();
+    }
+
+    assertThat(thread.getState()).isEqualTo(Thread.State.BLOCKED);
+  }
+
+  private static void join(Thread thread) throws InterruptedException {
+    thread.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS));
+    assertThat(thread.isAlive()).isFalse();
   }
 
   @SuppressWarnings("unchecked")
@@ -154,9 +177,49 @@ public class TestStandardEncryptionManagerConcurrency {
     try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
       out.writeObject(value);
     }
+
     try (ObjectInputStream in =
         new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
       return (T) in.readObject();
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  private static class BlockingKms extends UnitestKMS {
+    private final AtomicInteger wrapCalls = new AtomicInteger();
+    private transient CountDownLatch wrapEntered = new CountDownLatch(1);
+    private transient CountDownLatch allowWrap = new CountDownLatch(1);
+
+    @Override
+    public ByteBuffer wrapKey(ByteBuffer key, String wrappingKeyId) {
+      wrapCalls.incrementAndGet();
+      wrapEntered.countDown();
+      try {
+        if (!allowWrap.await(WAIT_SECONDS, TimeUnit.SECONDS)) {
+          throw new AssertionError("Timed out waiting to release key wrapping");
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("Interrupted while waiting to wrap key", e);
+      }
+
+      return super.wrapKey(key, wrappingKeyId);
+    }
+
+    private void awaitWrap() throws InterruptedException {
+      assertThat(wrapEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private void releaseWrap() {
+      allowWrap.countDown();
+    }
+
+    private int wrapCalls() {
+      return wrapCalls.get();
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -159,6 +159,26 @@ class TestStandardEncryptionManagerConcurrency {
   }
 
   @Test
+  void managerCopiesInputKeyMetadata() {
+    UnitestKMS kms = new UnitestKMS();
+    kms.initialize(Map.of());
+    byte[] metadata = {1, 2, 3};
+    EncryptedKey inputKey =
+        new BaseEncryptedKey(
+            "key-id",
+            ByteBuffer.wrap(metadata),
+            UnitestKMS.MASTER_KEY_NAME1,
+            Map.of(StandardEncryptionManager.KEY_TIMESTAMP, "0"));
+    StandardEncryptionManager manager =
+        new StandardEncryptionManager(List.of(inputKey), UnitestKMS.MASTER_KEY_NAME1, 16, kms);
+
+    inputKey.encryptedKeyMetadata().put(0, (byte) 4);
+
+    assertThat(manager.encryptionKeys().get("key-id").encryptedKeyMetadata())
+        .isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+  }
+
+  @Test
   void manifestListDecryptionDoesNotCopyAllKeys() {
     UnitestKMS kms = new UnitestKMS();
     kms.initialize(Map.of());

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.iceberg.ManifestListFile;
 import org.junit.jupiter.api.Test;
 
 class TestStandardEncryptionManagerConcurrency {
@@ -131,6 +132,23 @@ class TestStandardEncryptionManagerConcurrency {
     StandardEncryptionManager manager = newManager(new UnitestKMS());
     String firstKey = manager.addManifestListKeyMetadata(keyMetadata());
     Map<String, EncryptedKey> snapshot = manager.encryptionKeys();
+    EncryptedKey manifestListKey = snapshot.get(firstKey);
+    EncryptedKey keyEncryptionKey = snapshot.get(manifestListKey.encryptedById());
+    byte metadataByte = manifestListKey.encryptedKeyMetadata().get(0);
+    String keyTimestamp =
+        keyEncryptionKey.properties().get(StandardEncryptionManager.KEY_TIMESTAMP);
+
+    manifestListKey.encryptedKeyMetadata().put(0, (byte) (metadataByte + 1));
+    keyEncryptionKey.properties().put(StandardEncryptionManager.KEY_TIMESTAMP, "modified");
+
+    Map<String, EncryptedKey> current = manager.encryptionKeys();
+    assertThat(current.get(firstKey).encryptedKeyMetadata().get(0)).isEqualTo(metadataByte);
+    assertThat(
+            current
+                .get(manifestListKey.encryptedById())
+                .properties()
+                .get(StandardEncryptionManager.KEY_TIMESTAMP))
+        .isEqualTo(keyTimestamp);
 
     String secondKey = manager.addManifestListKeyMetadata(keyMetadata());
 
@@ -138,6 +156,44 @@ class TestStandardEncryptionManagerConcurrency {
     assertThatThrownBy(snapshot::clear)
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage(null);
+  }
+
+  @Test
+  void manifestListDecryptionDoesNotCopyAllKeys() {
+    UnitestKMS kms = new UnitestKMS();
+    kms.initialize(Map.of());
+    StandardEncryptionManager manager =
+        new StandardEncryptionManager(List.of(), UnitestKMS.MASTER_KEY_NAME1, 16, kms) {
+          @Override
+          synchronized Map<String, EncryptedKey> encryptionKeys() {
+            throw new AssertionError("Manifest list decryption must not copy all encryption keys");
+          }
+        };
+    String keyId = manager.addManifestListKeyMetadata(keyMetadata());
+
+    ByteBuffer decrypted =
+        EncryptionUtil.decryptManifestListKeyMetadata(manifestList(keyId), manager);
+
+    assertThat(decrypted).isEqualTo(keyMetadata().buffer());
+  }
+
+  private static ManifestListFile manifestList(String keyId) {
+    return new ManifestListFile() {
+      @Override
+      public String location() {
+        return "manifest-list.avro";
+      }
+
+      @Override
+      public String encryptionKeyID() {
+        return keyId;
+      }
+
+      @Override
+      public ByteBuffer decryptKeyMetadata(EncryptionManager encryptionManager) {
+        return EncryptionUtil.decryptManifestListKeyMetadata(this, encryptionManager);
+      }
+    };
   }
 
   private static StandardEncryptionManager newManager(UnitestKMS kms) {

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -135,7 +135,9 @@ class TestStandardEncryptionManagerConcurrency {
     String secondKey = manager.addManifestListKeyMetadata(keyMetadata());
 
     assertThat(snapshot).containsKey(firstKey).doesNotContainKey(secondKey).hasSize(2);
-    assertThatThrownBy(snapshot::clear).isInstanceOf(UnsupportedOperationException.class);
+    assertThatThrownBy(snapshot::clear)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
   }
 
   private static StandardEncryptionManager newManager(UnitestKMS kms) {


### PR DESCRIPTION
Bottom of the #22 -> #19 -> #20 stack. This supersedes #16.

`StandardEncryptionManager` stores manifest-list keys in a mutable map shared by key minting, reads, and serialization. Unsynchronized check-then-mint can create duplicate key-encryption keys, readers can observe mutation, and serialization can traverse partial state.

This change synchronizes key-map mutation, reads, lazy cache access, and serialization. `encryptionKeys()` returns an immutable snapshot whose key values are detached from manager state rather than exposing the live map. Manifest-list decryption uses targeted synchronized lookups so scan planning does not copy the growing key map. The public API is unchanged.

Constructor keys are copied into manager-owned state. The tests use a blocking KMS to hold one mint inside the critical section. They deterministically prove a competing mint creates only one KEK, serialization waits for a complete MLK/KEK pair, returned maps and key values are isolated, retained constructor inputs cannot mutate manager state, and manifest-list decryption avoids a full-map snapshot.

Validation: `:iceberg-core:test --tests org.apache.iceberg.encryption.TestStandardEncryptionManagerConcurrency`; `:iceberg-core:spotlessCheck`.

---
**AI Disclosure**
- Model: Claude Opus 4.8; GPT-5
- Platform/Tool: Claude Code; OpenAI Codex
- Human Oversight: unreviewed
- Prompt Summary: Make shared encryption-manager key state thread-safe and replace probabilistic tests with controlled interleavings.
