### PR TITLE
Core: Protect standard encryption key state

### DIFF
--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
@@ -148,14 +148,12 @@ public class EncryptionUtil {
         "Snapshot key metadata encryption requires a StandardEncryptionManager");
     StandardEncryptionManager sem = (StandardEncryptionManager) em;
     String manifestListKeyId = manifestList.encryptionKeyID();
-    Map<String, EncryptedKey> encryptionKeys = sem.encryptionKeys();
-    EncryptedKey manifestListKey = encryptionKeys.get(manifestListKeyId);
+    EncryptedKey manifestListKey = sem.encryptionKey(manifestListKeyId);
     ByteBuffer encryptedKeyMetadata = manifestListKey.encryptedKeyMetadata();
     String keyEncryptionKeyID = manifestListKey.encryptedById();
     ByteBuffer keyEncryptionKey = sem.encryptedByKey(manifestListKeyId);
     String keyEncryptionKeyTimestamp =
-        encryptionKeys
-            .get(keyEncryptionKeyID)
+        sem.encryptionKey(keyEncryptionKeyID)
             .properties()
             .get(StandardEncryptionManager.KEY_TIMESTAMP);
     Preconditions.checkState(
@@ -173,6 +171,15 @@ public class EncryptionUtil {
     return ByteBuffer.wrap(decryptedKeyMetadata);
   }
 
+  /**
+   * Returns a mutable point-in-time copy of the standard encryption manager's key registry.
+   *
+   * <p>Changes to the returned map or its detached key values do not affect the manager.
+   *
+   * @param em the table's encryption manager
+   * @return a mutable detached copy of the encryption-key registry
+   * @throws IllegalStateException if the manager is not a {@link StandardEncryptionManager}
+   */
   public static Map<String, EncryptedKey> encryptionKeys(EncryptionManager em) {
     Preconditions.checkState(
         em instanceof StandardEncryptionManager,

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.encryption;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Base64;
@@ -37,6 +39,10 @@ import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.SerializableMap;
 
 public class StandardEncryptionManager implements EncryptionManager {
+  // Keep the UID computed before this class gained synchronization helpers so serialized managers
+  // remain compatible.
+  private static final long serialVersionUID = -5497522897222558303L;
+
   // Maximal lifespan of key encryption keys is 2 years according to NIST SP 800-57 (PART 1 REV. 5,
   // section 5.3.6.7.b)
   private static final long KEY_ENCRYPTION_KEY_LIFESPAN_MS = TimeUnit.DAYS.toMillis(730);
@@ -87,11 +93,16 @@ public class StandardEncryptionManager implements EncryptionManager {
     this.encryptionKeys = SerializableMap.copyOf(Maps.newLinkedHashMap());
     if (keys != null) {
       for (EncryptedKey key : keys) {
-        this.encryptionKeys.put(
-            key.keyId(),
-            new BaseEncryptedKey(
-                key.keyId(), key.encryptedKeyMetadata(), key.encryptedById(), key.properties()));
+        this.encryptionKeys.put(key.keyId(), copyKey(key));
       }
+    }
+  }
+
+  private void writeObject(ObjectOutputStream out) throws IOException {
+    // Key registry mutations use the same monitor. Hold it while serializing so a stream cannot
+    // contain a manifest-list key without the key-encryption key that wraps it.
+    synchronized (this) {
+      out.defaultWriteObject();
     }
   }
 
@@ -116,17 +127,19 @@ public class StandardEncryptionManager implements EncryptionManager {
   }
 
   private LoadingCache<String, ByteBuffer> unwrappedKeyCache() {
-    if (this.unwrappedKeyCache == null) {
-      this.unwrappedKeyCache =
-          Caffeine.newBuilder()
-              .expireAfterWrite(1, TimeUnit.HOURS)
-              .build(
-                  keyId ->
-                      kmsClient.unwrapKey(
-                          encryptionKeys.get(keyId).encryptedKeyMetadata(), tableKeyId));
-    }
+    synchronized (this) {
+      if (this.unwrappedKeyCache == null) {
+        this.unwrappedKeyCache =
+            Caffeine.newBuilder()
+                .expireAfterWrite(1, TimeUnit.HOURS)
+                .build(
+                    keyId ->
+                        ByteBuffers.copy(
+                            kmsClient.unwrapKey(encryptedKeyMetadata(keyId), tableKeyId)));
+      }
 
-    return unwrappedKeyCache;
+      return unwrappedKeyCache;
+    }
   }
 
   private SecureRandom workerRNG() {
@@ -154,39 +167,55 @@ public class StandardEncryptionManager implements EncryptionManager {
   }
 
   Map<String, EncryptedKey> encryptionKeys() {
-    return encryptionKeys;
+    synchronized (this) {
+      Map<String, EncryptedKey> snapshot = Maps.newLinkedHashMap();
+      encryptionKeys.forEach((keyId, key) -> snapshot.put(keyId, copyKey(key)));
+      return snapshot;
+    }
+  }
+
+  EncryptedKey encryptionKey(String keyId) {
+    synchronized (this) {
+      EncryptedKey key = encryptionKeys.get(keyId);
+      return key != null ? copyKey(key) : null;
+    }
   }
 
   String keyEncryptionKeyID() {
-    // Find unexpired key encryption key
-    for (String keyID : encryptionKeys.keySet()) {
-      EncryptedKey key = encryptionKeys.get(keyID);
-      if (key.encryptedById().equals(tableKeyId)) { // this is a key encryption key
-        String timestampProperty = key.properties().get(KEY_TIMESTAMP);
-        long keyTimestamp = Long.parseLong(timestampProperty);
-        if (currentTimeMillis() - keyTimestamp < KEY_ENCRYPTION_KEY_LIFESPAN_MS) {
-          return keyID;
+    synchronized (this) {
+      // Find unexpired key encryption key
+      for (String keyID : encryptionKeys.keySet()) {
+        EncryptedKey key = encryptionKeys.get(keyID);
+        if (key.encryptedById().equals(tableKeyId)) { // this is a key encryption key
+          String timestampProperty = key.properties().get(KEY_TIMESTAMP);
+          long keyTimestamp = Long.parseLong(timestampProperty);
+          if (currentTimeMillis() - keyTimestamp < KEY_ENCRYPTION_KEY_LIFESPAN_MS) {
+            return keyID;
+          }
         }
       }
+
+      // No unexpired key encryption keys; create one
+      ByteBuffer unwrapped = newKey();
+      ByteBuffer wrapped = kmsClient.wrapKey(ByteBuffers.copy(unwrapped), tableKeyId);
+      Map<String, String> properties = Maps.newHashMap();
+      properties.put(KEY_TIMESTAMP, "" + currentTimeMillis());
+      EncryptedKey key =
+          new BaseEncryptedKey(generateKeyId(), ByteBuffers.copy(wrapped), tableKeyId, properties);
+
+      // update internal tracking
+      unwrappedKeyCache().put(key.keyId(), ByteBuffers.copy(unwrapped));
+      encryptionKeys.put(key.keyId(), key);
+
+      return key.keyId();
     }
-
-    // No unexpired key encryption keys; create one
-    ByteBuffer unwrapped = newKey();
-    ByteBuffer wrapped = kmsClient.wrapKey(unwrapped, tableKeyId);
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(KEY_TIMESTAMP, "" + currentTimeMillis());
-    EncryptedKey key = new BaseEncryptedKey(generateKeyId(), wrapped, tableKeyId, properties);
-
-    // update internal tracking
-    unwrappedKeyCache().put(key.keyId(), unwrapped);
-    encryptionKeys.put(key.keyId(), key);
-
-    return key.keyId();
   }
 
   // For key rotation tests
   void setTestTimeShift(long shift) {
-    testTimeShift = shift;
+    synchronized (this) {
+      testTimeShift = shift;
+    }
   }
 
   private long currentTimeMillis() {
@@ -194,33 +223,46 @@ public class StandardEncryptionManager implements EncryptionManager {
   }
 
   ByteBuffer encryptedByKey(String manifestListKeyID) {
-    EncryptedKey encryptedKeyMetadata = encryptionKeys.get(manifestListKeyID);
+    String keyEncryptionKeyID;
+    synchronized (this) {
+      EncryptedKey encryptedKeyMetadata = encryptionKeys.get(manifestListKeyID);
 
-    Preconditions.checkState(
-        encryptedKeyMetadata != null,
-        "Cannot find manifest list key metadata with id %s",
-        manifestListKeyID);
+      Preconditions.checkState(
+          encryptedKeyMetadata != null,
+          "Cannot find manifest list key metadata with id %s",
+          manifestListKeyID);
 
-    Preconditions.checkArgument(
-        !encryptedKeyMetadata.encryptedById().equals(tableKeyId),
-        "%s is a key encryption key, not manifest list key metadata",
-        manifestListKeyID);
+      Preconditions.checkArgument(
+          !encryptedKeyMetadata.encryptedById().equals(tableKeyId),
+          "%s is a key encryption key, not manifest list key metadata",
+          manifestListKeyID);
 
-    return unwrappedKeyCache().get(encryptedKeyMetadata.encryptedById());
+      keyEncryptionKeyID = encryptedKeyMetadata.encryptedById();
+    }
+
+    return unwrappedKey(keyEncryptionKeyID);
   }
 
   public String addManifestListKeyMetadata(NativeEncryptionKeyMetadata keyMetadata) {
     String manifestListKeyID = generateKeyId();
-    String keyEncryptionKeyID = keyEncryptionKeyID();
-    String keyEncryptionKeyTimestamp =
-        encryptionKeys.get(keyEncryptionKeyID).properties().get(KEY_TIMESTAMP);
+    String keyEncryptionKeyID;
+    String keyEncryptionKeyTimestamp;
+    synchronized (this) {
+      keyEncryptionKeyID = keyEncryptionKeyID();
+      keyEncryptionKeyTimestamp =
+          encryptionKeys.get(keyEncryptionKeyID).properties().get(KEY_TIMESTAMP);
+    }
+
     ByteBuffer encryptedKeyMetadata =
         EncryptionUtil.encryptManifestListKeyMetadata(
-            unwrappedKeyCache().get(keyEncryptionKeyID), keyEncryptionKeyTimestamp, keyMetadata);
+            unwrappedKey(keyEncryptionKeyID), keyEncryptionKeyTimestamp, keyMetadata);
     BaseEncryptedKey key =
-        new BaseEncryptedKey(manifestListKeyID, encryptedKeyMetadata, keyEncryptionKeyID, null);
+        new BaseEncryptedKey(
+            manifestListKeyID, ByteBuffers.copy(encryptedKeyMetadata), keyEncryptionKeyID, null);
 
-    encryptionKeys.put(key.keyId(), key);
+    synchronized (this) {
+      encryptionKeys.put(key.keyId(), key);
+    }
 
     return manifestListKeyID;
   }
@@ -235,6 +277,26 @@ public class StandardEncryptionManager implements EncryptionManager {
     byte[] newKey = new byte[dataKeyLength];
     workerRNG().nextBytes(newKey);
     return ByteBuffer.wrap(newKey);
+  }
+
+  private ByteBuffer encryptedKeyMetadata(String keyId) {
+    synchronized (this) {
+      return ByteBuffers.copy(encryptionKeys.get(keyId).encryptedKeyMetadata());
+    }
+  }
+
+  private ByteBuffer unwrappedKey(String keyId) {
+    return ByteBuffers.copy(unwrappedKeyCache().get(keyId));
+  }
+
+  private static EncryptedKey copyKey(EncryptedKey key) {
+    // BaseEncryptedKey may retain a full heap buffer's backing array, so copy the buffer first.
+    // Its constructor already copies the properties map.
+    return new BaseEncryptedKey(
+        key.keyId(),
+        ByteBuffers.copy(key.encryptedKeyMetadata()),
+        key.encryptedById(),
+        key.properties());
   }
 
   private class StandardEncryptedOutputFile implements NativeEncryptionOutputFile {

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -61,12 +61,10 @@ class TestStandardEncryptionManagerConcurrency {
             });
 
     first.start();
-    kms.awaitWrap();
-    second.start();
-    assertThat(secondStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
     try {
-      awaitBlocked(second);
-      assertThat(kms.wrapCalls()).isEqualTo(1);
+      kms.awaitWrap();
+      second.start();
+      assertThat(secondStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
     } finally {
       kms.releaseWrap();
       join(first);
@@ -74,6 +72,7 @@ class TestStandardEncryptionManagerConcurrency {
     }
 
     assertThat(failure.get()).isNull();
+    assertThat(kms.wrapCalls()).isEqualTo(1);
     assertThat(manager.encryptionKeys()).containsKeys(firstKey.get(), secondKey.get()).hasSize(3);
     assertThat(
             manager.encryptionKeys().values().stream()
@@ -82,7 +81,7 @@ class TestStandardEncryptionManagerConcurrency {
   }
 
   @Test
-  void serializationDoesNotOverlapKeyRegistryTransition() throws Exception {
+  void serializationDoesNotExposeIncompleteKeyRegistry() throws Exception {
     BlockingKms kms = new BlockingKms();
     StandardEncryptionManager manager = newManager(kms);
     AtomicReference<StandardEncryptionManager> serialized = new AtomicReference<>();
@@ -98,12 +97,10 @@ class TestStandardEncryptionManagerConcurrency {
             });
 
     minter.start();
-    kms.awaitWrap();
-    serializer.start();
-    assertThat(serializationStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
     try {
-      awaitBlocked(serializer);
-      assertThat(serialized.get()).isNull();
+      kms.awaitWrap();
+      serializer.start();
+      assertThat(serializationStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
     } finally {
       kms.releaseWrap();
       join(minter);
@@ -115,7 +112,7 @@ class TestStandardEncryptionManagerConcurrency {
   }
 
   @Test
-  void snapshotDoesNotOverlapKeyRegistryTransition() throws Exception {
+  void snapshotDoesNotExposeIncompleteKeyRegistry() throws Exception {
     BlockingKms kms = new BlockingKms();
     StandardEncryptionManager manager = newManager(kms);
     AtomicReference<Map<String, EncryptedKey>> snapshot = new AtomicReference<>();
@@ -131,12 +128,10 @@ class TestStandardEncryptionManagerConcurrency {
             });
 
     minter.start();
-    kms.awaitWrap();
-    reader.start();
-    assertThat(snapshotStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
     try {
-      awaitBlocked(reader);
-      assertThat(snapshot.get()).isNull();
+      kms.awaitWrap();
+      reader.start();
+      assertThat(snapshotStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
     } finally {
       kms.releaseWrap();
       join(minter);
@@ -260,17 +255,6 @@ class TestStandardEncryptionManagerConcurrency {
     } catch (Throwable t) {
       failure.compareAndSet(null, t);
     }
-  }
-
-  private static void awaitBlocked(Thread thread) {
-    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(WAIT_SECONDS);
-    while (thread.isAlive()
-        && thread.getState() != Thread.State.BLOCKED
-        && System.nanoTime() < deadline) {
-      Thread.yield();
-    }
-
-    assertThat(thread.getState()).isEqualTo(Thread.State.BLOCKED);
   }
 
   private static void join(Thread thread) throws InterruptedException {

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -41,11 +41,10 @@ class TestStandardEncryptionManagerConcurrency {
   @Test
   void concurrentMintingCreatesOneKeyEncryptionKey() throws Exception {
     BlockingKms kms = new BlockingKms();
-    StandardEncryptionManager manager = newManager(kms);
+    InvocationTrackingManager manager = newInvocationTrackingManager(kms);
     AtomicReference<String> firstKey = new AtomicReference<>();
     AtomicReference<String> secondKey = new AtomicReference<>();
     AtomicReference<Throwable> failure = new AtomicReference<>();
-    CountDownLatch secondStarted = new CountDownLatch(1);
     Thread first =
         new Thread(
             () ->
@@ -54,17 +53,16 @@ class TestStandardEncryptionManagerConcurrency {
                     failure));
     Thread second =
         new Thread(
-            () -> {
-              secondStarted.countDown();
-              capture(
-                  () -> secondKey.set(manager.addManifestListKeyMetadata(keyMetadata())), failure);
-            });
+            () ->
+                capture(
+                    () -> secondKey.set(manager.addManifestListKeyMetadata(keyMetadata())),
+                    failure));
 
     first.start();
     try {
       kms.awaitWrap();
       second.start();
-      assertThat(secondStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+      manager.awaitAddInvocations();
     } finally {
       kms.releaseWrap();
       join(first);
@@ -83,24 +81,19 @@ class TestStandardEncryptionManagerConcurrency {
   @Test
   void serializationDoesNotExposeIncompleteKeyRegistry() throws Exception {
     BlockingKms kms = new BlockingKms();
-    StandardEncryptionManager manager = newManager(kms);
+    InvocationTrackingManager manager = newInvocationTrackingManager(kms);
     AtomicReference<StandardEncryptionManager> serialized = new AtomicReference<>();
     AtomicReference<Throwable> failure = new AtomicReference<>();
-    CountDownLatch serializationStarted = new CountDownLatch(1);
     Thread minter =
         new Thread(() -> capture(() -> manager.addManifestListKeyMetadata(keyMetadata()), failure));
     Thread serializer =
-        new Thread(
-            () -> {
-              serializationStarted.countDown();
-              capture(() -> serialized.set(roundTrip(manager)), failure);
-            });
+        new Thread(() -> capture(() -> serialized.set(roundTrip(manager)), failure));
 
     minter.start();
     try {
       kms.awaitWrap();
       serializer.start();
-      assertThat(serializationStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+      manager.awaitSerializationInvocation();
     } finally {
       kms.releaseWrap();
       join(minter);
@@ -114,24 +107,19 @@ class TestStandardEncryptionManagerConcurrency {
   @Test
   void snapshotDoesNotExposeIncompleteKeyRegistry() throws Exception {
     BlockingKms kms = new BlockingKms();
-    StandardEncryptionManager manager = newManager(kms);
+    InvocationTrackingManager manager = newInvocationTrackingManager(kms);
     AtomicReference<Map<String, EncryptedKey>> snapshot = new AtomicReference<>();
     AtomicReference<Throwable> failure = new AtomicReference<>();
-    CountDownLatch snapshotStarted = new CountDownLatch(1);
     Thread minter =
         new Thread(() -> capture(() -> manager.addManifestListKeyMetadata(keyMetadata()), failure));
     Thread reader =
-        new Thread(
-            () -> {
-              snapshotStarted.countDown();
-              capture(() -> snapshot.set(manager.encryptionKeys()), failure);
-            });
+        new Thread(() -> capture(() -> snapshot.set(manager.encryptionKeys()), failure));
 
     minter.start();
     try {
       kms.awaitWrap();
       reader.start();
-      assertThat(snapshotStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+      manager.awaitSnapshotInvocation();
     } finally {
       kms.releaseWrap();
       join(minter);
@@ -230,6 +218,10 @@ class TestStandardEncryptionManagerConcurrency {
         List.of(), UnitestKMS.MASTER_KEY_NAME1, 16, initializedKms(kms));
   }
 
+  private static InvocationTrackingManager newInvocationTrackingManager(UnitestKMS kms) {
+    return new InvocationTrackingManager(initializedKms(kms));
+  }
+
   private static UnitestKMS initializedKms() {
     return initializedKms(new UnitestKMS());
   }
@@ -244,6 +236,7 @@ class TestStandardEncryptionManagerConcurrency {
   }
 
   private static void assertCompleteKeyPairs(Map<String, EncryptedKey> keys) {
+    assertThat(keys).isNotEmpty();
     keys.values().stream()
         .filter(key -> !UnitestKMS.MASTER_KEY_NAME1.equals(key.encryptedById()))
         .forEach(key -> assertThat(keys).containsKey(key.encryptedById()));
@@ -311,6 +304,48 @@ class TestStandardEncryptionManagerConcurrency {
 
     private int wrapCalls() {
       return wrapCalls.get();
+    }
+  }
+
+  private static class InvocationTrackingManager extends StandardEncryptionManager {
+    private final transient CountDownLatch addInvocations = new CountDownLatch(2);
+    private final transient CountDownLatch snapshotInvocation = new CountDownLatch(1);
+    private final transient CountDownLatch serializationInvocation = new CountDownLatch(1);
+
+    private InvocationTrackingManager(UnitestKMS kms) {
+      super(List.of(), UnitestKMS.MASTER_KEY_NAME1, 16, kms);
+    }
+
+    @Override
+    public String addManifestListKeyMetadata(NativeEncryptionKeyMetadata keyMetadata) {
+      addInvocations.countDown();
+      return super.addManifestListKeyMetadata(keyMetadata);
+    }
+
+    @Override
+    Map<String, EncryptedKey> encryptionKeys() {
+      if (snapshotInvocation != null) {
+        snapshotInvocation.countDown();
+      }
+
+      return super.encryptionKeys();
+    }
+
+    private Object writeReplace() {
+      serializationInvocation.countDown();
+      return this;
+    }
+
+    private void awaitAddInvocations() throws InterruptedException {
+      assertThat(addInvocations.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private void awaitSnapshotInvocation() throws InterruptedException {
+      assertThat(snapshotInvocation.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private void awaitSerializationInvocation() throws InterruptedException {
+      assertThat(serializationInvocation.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManagerConcurrency.java
@@ -1,0 +1,364 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.encryption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.ObjectStreamClass;
+import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+class TestStandardEncryptionManagerConcurrency {
+  private static final long WAIT_SECONDS = 10;
+  private static final long SERIAL_VERSION_UID = -5497522897222558303L;
+
+  @Test
+  void concurrentMintingCreatesOneKeyEncryptionKey() throws Exception {
+    BlockingKms kms = new BlockingKms();
+    StandardEncryptionManager manager = newManager(kms);
+    AtomicReference<String> firstKey = new AtomicReference<>();
+    AtomicReference<String> secondKey = new AtomicReference<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    CountDownLatch secondStarted = new CountDownLatch(1);
+    Thread first =
+        new Thread(
+            () ->
+                capture(
+                    () -> firstKey.set(manager.addManifestListKeyMetadata(keyMetadata())),
+                    failure));
+    Thread second =
+        new Thread(
+            () -> {
+              secondStarted.countDown();
+              capture(
+                  () -> secondKey.set(manager.addManifestListKeyMetadata(keyMetadata())), failure);
+            });
+
+    first.start();
+    kms.awaitWrap();
+    second.start();
+    assertThat(secondStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    try {
+      awaitBlocked(second);
+      assertThat(kms.wrapCalls()).isEqualTo(1);
+    } finally {
+      kms.releaseWrap();
+      join(first);
+      join(second);
+    }
+
+    assertThat(failure.get()).isNull();
+    assertThat(manager.encryptionKeys()).containsKeys(firstKey.get(), secondKey.get()).hasSize(3);
+    assertThat(
+            manager.encryptionKeys().values().stream()
+                .filter(key -> UnitestKMS.MASTER_KEY_NAME1.equals(key.encryptedById())))
+        .hasSize(1);
+  }
+
+  @Test
+  void serializationDoesNotOverlapKeyRegistryTransition() throws Exception {
+    BlockingKms kms = new BlockingKms();
+    StandardEncryptionManager manager = newManager(kms);
+    AtomicReference<StandardEncryptionManager> serialized = new AtomicReference<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    CountDownLatch serializationStarted = new CountDownLatch(1);
+    Thread minter =
+        new Thread(() -> capture(() -> manager.addManifestListKeyMetadata(keyMetadata()), failure));
+    Thread serializer =
+        new Thread(
+            () -> {
+              serializationStarted.countDown();
+              capture(() -> serialized.set(roundTrip(manager)), failure);
+            });
+
+    minter.start();
+    kms.awaitWrap();
+    serializer.start();
+    assertThat(serializationStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    try {
+      awaitBlocked(serializer);
+      assertThat(serialized.get()).isNull();
+    } finally {
+      kms.releaseWrap();
+      join(minter);
+      join(serializer);
+    }
+
+    assertThat(failure.get()).isNull();
+    assertCompleteKeyPairs(serialized.get().encryptionKeys());
+  }
+
+  @Test
+  void snapshotDoesNotOverlapKeyRegistryTransition() throws Exception {
+    BlockingKms kms = new BlockingKms();
+    StandardEncryptionManager manager = newManager(kms);
+    AtomicReference<Map<String, EncryptedKey>> snapshot = new AtomicReference<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    CountDownLatch snapshotStarted = new CountDownLatch(1);
+    Thread minter =
+        new Thread(() -> capture(() -> manager.addManifestListKeyMetadata(keyMetadata()), failure));
+    Thread reader =
+        new Thread(
+            () -> {
+              snapshotStarted.countDown();
+              capture(() -> snapshot.set(manager.encryptionKeys()), failure);
+            });
+
+    minter.start();
+    kms.awaitWrap();
+    reader.start();
+    assertThat(snapshotStarted.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    try {
+      awaitBlocked(reader);
+      assertThat(snapshot.get()).isNull();
+    } finally {
+      kms.releaseWrap();
+      join(minter);
+      join(reader);
+    }
+
+    assertThat(failure.get()).isNull();
+    assertCompleteKeyPairs(snapshot.get());
+  }
+
+  @Test
+  void encryptionKeysReturnsMutableDetachedSnapshot() {
+    StandardEncryptionManager manager = newManager(new UnitestKMS());
+    String keyId = manager.addManifestListKeyMetadata(keyMetadata());
+    Map<String, EncryptedKey> snapshot = manager.encryptionKeys();
+    EncryptedKey manifestListKey = snapshot.get(keyId);
+    EncryptedKey keyEncryptionKey = snapshot.get(manifestListKey.encryptedById());
+    byte metadataByte = manifestListKey.encryptedKeyMetadata().get(0);
+    String keyTimestamp =
+        keyEncryptionKey.properties().get(StandardEncryptionManager.KEY_TIMESTAMP);
+
+    manifestListKey.encryptedKeyMetadata().put(0, (byte) (metadataByte + 1));
+    keyEncryptionKey.properties().put(StandardEncryptionManager.KEY_TIMESTAMP, "modified");
+    snapshot.clear();
+
+    Map<String, EncryptedKey> current = manager.encryptionKeys();
+    assertThat(snapshot).isEmpty();
+    assertThat(current.get(keyId).encryptedKeyMetadata().get(0)).isEqualTo(metadataByte);
+    assertThat(
+            current
+                .get(manifestListKey.encryptedById())
+                .properties()
+                .get(StandardEncryptionManager.KEY_TIMESTAMP))
+        .isEqualTo(keyTimestamp);
+  }
+
+  @Test
+  void constructorDetachesCallerOwnedKeyState() {
+    BaseEncryptedKey input =
+        new BaseEncryptedKey(
+            "key-id",
+            ByteBuffer.wrap(new byte[] {1, 2, 3}),
+            UnitestKMS.MASTER_KEY_NAME1,
+            Map.of(StandardEncryptionManager.KEY_TIMESTAMP, "timestamp"));
+    StandardEncryptionManager manager =
+        new StandardEncryptionManager(
+            List.of(input), UnitestKMS.MASTER_KEY_NAME1, 16, initializedKms());
+
+    input.encryptedKeyMetadata().put(0, (byte) 9);
+    input.properties().put(StandardEncryptionManager.KEY_TIMESTAMP, "modified");
+
+    EncryptedKey retained = manager.encryptionKey(input.keyId());
+    assertThat(retained.encryptedKeyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    assertThat(retained.properties())
+        .containsEntry(StandardEncryptionManager.KEY_TIMESTAMP, "timestamp");
+  }
+
+  @Test
+  void kmsBuffersCannotMutateManagerState() {
+    MutableBufferKms mintingKms = new MutableBufferKms();
+    StandardEncryptionManager manager = newManager(mintingKms);
+    String manifestListKeyId = manager.addManifestListKeyMetadata(keyMetadata());
+    EncryptedKey manifestListKey = manager.encryptionKey(manifestListKeyId);
+    String keyEncryptionKeyId = manifestListKey.encryptedById();
+    ByteBuffer unwrappedKey = manager.encryptedByKey(manifestListKeyId);
+    ByteBuffer wrappedKey = manager.encryptionKey(keyEncryptionKeyId).encryptedKeyMetadata();
+
+    mintingKms.mutateWrapBuffers();
+
+    assertThat(manager.encryptedByKey(manifestListKeyId)).isEqualTo(unwrappedKey);
+    assertThat(manager.encryptionKey(keyEncryptionKeyId).encryptedKeyMetadata())
+        .isEqualTo(wrappedKey);
+
+    MutableBufferKms loadingKms = new MutableBufferKms();
+    StandardEncryptionManager reloaded =
+        new StandardEncryptionManager(
+            List.copyOf(manager.encryptionKeys().values()),
+            UnitestKMS.MASTER_KEY_NAME1,
+            16,
+            initializedKms(loadingKms));
+    ByteBuffer loadedKey = reloaded.encryptedByKey(manifestListKeyId);
+
+    loadingKms.mutateUnwrapBuffer();
+
+    assertThat(reloaded.encryptedByKey(manifestListKeyId)).isEqualTo(loadedKey);
+  }
+
+  @Test
+  void serialVersionUidRemainsCompatible() {
+    assertThat(ObjectStreamClass.lookup(StandardEncryptionManager.class).getSerialVersionUID())
+        .isEqualTo(SERIAL_VERSION_UID);
+  }
+
+  private static StandardEncryptionManager newManager(UnitestKMS kms) {
+    return new StandardEncryptionManager(
+        List.of(), UnitestKMS.MASTER_KEY_NAME1, 16, initializedKms(kms));
+  }
+
+  private static UnitestKMS initializedKms() {
+    return initializedKms(new UnitestKMS());
+  }
+
+  private static <T extends UnitestKMS> T initializedKms(T kms) {
+    kms.initialize(Map.of());
+    return kms;
+  }
+
+  private static NativeEncryptionKeyMetadata keyMetadata() {
+    return new StandardKeyMetadata(new byte[16], new byte[16]);
+  }
+
+  private static void assertCompleteKeyPairs(Map<String, EncryptedKey> keys) {
+    keys.values().stream()
+        .filter(key -> !UnitestKMS.MASTER_KEY_NAME1.equals(key.encryptedById()))
+        .forEach(key -> assertThat(keys).containsKey(key.encryptedById()));
+  }
+
+  private static void capture(ThrowingRunnable action, AtomicReference<Throwable> failure) {
+    try {
+      action.run();
+    } catch (Throwable t) {
+      failure.compareAndSet(null, t);
+    }
+  }
+
+  private static void awaitBlocked(Thread thread) {
+    long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(WAIT_SECONDS);
+    while (thread.isAlive()
+        && thread.getState() != Thread.State.BLOCKED
+        && System.nanoTime() < deadline) {
+      Thread.yield();
+    }
+
+    assertThat(thread.getState()).isEqualTo(Thread.State.BLOCKED);
+  }
+
+  private static void join(Thread thread) throws InterruptedException {
+    thread.join(TimeUnit.SECONDS.toMillis(WAIT_SECONDS));
+    assertThat(thread.isAlive()).isFalse();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTrip(T value) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(value);
+    }
+
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) in.readObject();
+    }
+  }
+
+  @FunctionalInterface
+  private interface ThrowingRunnable {
+    void run() throws Exception;
+  }
+
+  private static class BlockingKms extends UnitestKMS {
+    private final AtomicInteger wrapCalls = new AtomicInteger();
+    private transient CountDownLatch wrapEntered = new CountDownLatch(1);
+    private transient CountDownLatch allowWrap = new CountDownLatch(1);
+
+    @Override
+    public ByteBuffer wrapKey(ByteBuffer key, String wrappingKeyId) {
+      wrapCalls.incrementAndGet();
+      wrapEntered.countDown();
+      try {
+        if (!allowWrap.await(WAIT_SECONDS, TimeUnit.SECONDS)) {
+          throw new AssertionError("Timed out waiting to release key wrapping");
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new AssertionError("Interrupted while waiting to wrap key", e);
+      }
+
+      return super.wrapKey(key, wrappingKeyId);
+    }
+
+    private void awaitWrap() throws InterruptedException {
+      assertThat(wrapEntered.await(WAIT_SECONDS, TimeUnit.SECONDS)).isTrue();
+    }
+
+    private void releaseWrap() {
+      allowWrap.countDown();
+    }
+
+    private int wrapCalls() {
+      return wrapCalls.get();
+    }
+  }
+
+  private static class MutableBufferKms extends UnitestKMS {
+    private ByteBuffer wrapInput;
+    private ByteBuffer wrapOutput;
+    private ByteBuffer unwrapOutput;
+
+    @Override
+    public ByteBuffer wrapKey(ByteBuffer key, String wrappingKeyId) {
+      this.wrapInput = key;
+      this.wrapOutput = super.wrapKey(key, wrappingKeyId);
+      return wrapOutput;
+    }
+
+    @Override
+    public ByteBuffer unwrapKey(ByteBuffer wrappedKey, String wrappingKeyId) {
+      this.unwrapOutput = super.unwrapKey(wrappedKey, wrappingKeyId);
+      return unwrapOutput;
+    }
+
+    private void mutateWrapBuffers() {
+      mutate(wrapInput);
+      mutate(wrapOutput);
+    }
+
+    private void mutateUnwrapBuffer() {
+      mutate(unwrapOutput);
+    }
+
+    private static void mutate(ByteBuffer buffer) {
+      buffer.put(0, (byte) (buffer.get(0) + 1));
+    }
+  }
+}


### PR DESCRIPTION
## Failure on `main`

`StandardEncryptionManager` does not make creation of the current key-encryption key (KEK) one
state transition. The exact latch-controlled test added here blocks the first manifest-list-key
mint inside the KMS, starts a second mint, and waits until both calls have entered the manager.

On this PR's immediate base, both calls wrap a different KEK: the test observes two KMS wraps where
one is expected. On this head it observes one shared KEK, two manifest-list keys, and three complete
registry entries.

The same mutable registry is read by commit, decryption, and Java-serialization paths. It previously
exposed its live map and retained mutable key buffers across caller and KMS boundaries.

This is independent manager-state correctness work. It does not fix the committed snapshot key-loss
bug; #27 does that.

## Root cause

Finding or creating the current KEK is a check-then-mutate operation over an unsynchronized map.
Registry snapshots and serialization can also race a key-pair insertion. `BaseEncryptedKey` is not
an ownership boundary by itself: a full heap `ByteBuffer` can retain its backing array, and key
metadata and properties are mutable values.

## Change

- Protect KEK creation, key insertion and lookup, registry snapshots, and Java serialization with
  the manager monitor. This serializes key-state transitions, not whole manifest-list-key calls;
  encryption work that does not require registry atomicity remains outside the monitor.
- Return detached values from the existing registry accessor and use a targeted detached lookup for
  decryption, avoiding a full-history copy on each read.
- Copy mutable buffers and properties only where ownership changes: constructor input, KMS
  input/output, and values leaving the registry.
- Pin the previously computed serialization UID and serialize under the same state boundary.

The existing public insertion API and successful-call contract are unchanged.

## Evidence

- Immediate base: `concurrentMintingCreatesOneKeyEncryptionKey` fails deterministically with
  `expected: 1 but was: 2` KMS wraps.
- This head: the full `TestStandardEncryptionManagerConcurrency` class passes. Its overlap tests wait
  at actual manager/serialization entry points and require non-empty state with no MLK missing its
  wrapping KEK. A KEK without an MLK is valid while the first MLK is still being encrypted.
- Focused coverage also verifies detached output, constructor and KMS alias isolation, and retained
  Java serialization compatibility.

## Stack boundary

This is PR 1 of 3 and is independently correct. It is a prerequisite for #27 because that PR takes
a detached registry snapshot while other writers may be minting keys. #28 handles the encrypted
transaction regression exposed by #27.

---
**AI Disclosure**
- Model: OpenAI GPT-5 Codex
- Platform/Tool: OpenAI Codex
- Human Oversight: partially reviewed
- Prompt Summary: Diagnose and fix concurrent access and mutable aliases in standard-encryption key state as the first PR in a three-PR correctness stack.
