### PR TITLE
Core, Hive: Scope transaction encryption to staged metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -66,7 +66,7 @@ public class BaseTransaction implements Transaction {
   private final String tableName;
   private final TableOperations ops;
   private final TransactionTable transactionTable;
-  private final TableOperations transactionOps;
+  private final TransactionTableOperations transactionOps;
   private final List<PendingUpdate> updates;
   private final Set<String> deletedFiles =
       Sets.newHashSet(); // keep track of files deleted in the most recent commit
@@ -445,6 +445,7 @@ public class BaseTransaction implements Transaction {
       // use refreshed the metadata
       this.base = underlyingOps.current();
       this.current = underlyingOps.current();
+      transactionOps.resetTempOps();
       for (PendingUpdate update : updates) {
         // re-commit each update in the chain to apply it and update current
         try {
@@ -482,6 +483,10 @@ public class BaseTransaction implements Transaction {
 
   public class TransactionTableOperations implements TableOperations {
     private TableOperations tempOps = ops.temp(current);
+
+    private void resetTempOps() {
+      this.tempOps = ops.temp(current);
+    }
 
     @Override
     public TableMetadata current() {

--- a/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
@@ -112,6 +112,7 @@ class TestManifestListKeyPersistence {
         .snapshots()
         .forEach(
             snapshot -> {
+              assertSnapshotKeysCommitted(committed, snapshot);
               assertThat(snapshot.allManifests(table.io())).isNotEmpty();
               assertReadableFromCommittedKeys(committed, snapshot);
             });

--- a/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListKeyPersistence.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.encryption.EncryptionTestHelpers;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.UnitestKMS;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.junit.jupiter.api.AfterEach;
@@ -94,6 +95,28 @@ class TestManifestListKeyPersistence {
     assertReadableFromCommittedKeys(committed, snapshot);
   }
 
+  @Test
+  void transactionRebasePreservesManifestListKeys() {
+    TestTables.TestTable table = createEncryptedTable("mlk-rebase");
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(TestBase.FILE_A).commit();
+    List<String> stagedKeyIds = keyIds(((BaseTransaction) transaction).currentMetadata());
+
+    table.newFastAppend().appendFile(TestBase.FILE_B).commit();
+    transaction.commitTransaction();
+
+    TableMetadata committed = table.ops().current();
+    assertThat(committed.snapshots()).hasSize(2);
+    assertThat(keyIds(committed)).doesNotContainAnyElementsOf(stagedKeyIds);
+    committed
+        .snapshots()
+        .forEach(
+            snapshot -> {
+              assertThat(snapshot.allManifests(table.io())).isNotEmpty();
+              assertReadableFromCommittedKeys(committed, snapshot);
+            });
+  }
+
   private static KeyManagementClient kmsClient() {
     return EncryptionUtil.createKmsClient(
         ImmutableMap.of(
@@ -130,18 +153,69 @@ class TestManifestListKeyPersistence {
   }
 
   private TestTables.TestTable createEncryptedTable(String name) {
-    EncryptionManager encryption = EncryptionTestHelpers.createEncryptionManager();
+    EncryptionManager initialEncryption = EncryptionTestHelpers.createEncryptionManager();
     File dir = temp.resolve(name).toFile();
+    FileIO plainFileIO = new TestTables.LocalFileIO();
     TestTables.TestTableOperations ops =
         new TestTables.TestTableOperations(
-            name, dir, EncryptingFileIO.combine(new TestTables.LocalFileIO(), encryption)) {
+            name, dir, EncryptingFileIO.combine(plainFileIO, initialEncryption)) {
+          private EncryptionManager currentEncryption = initialEncryption;
+          private FileIO currentFileIO = EncryptingFileIO.combine(plainFileIO, currentEncryption);
+
           @Override
           public EncryptionManager encryption() {
-            return encryption;
+            return currentEncryption;
+          }
+
+          @Override
+          public FileIO io() {
+            return currentFileIO;
+          }
+
+          @Override
+          public void commit(TableMetadata base, TableMetadata metadata) {
+            super.commit(base, metadata);
+            this.currentEncryption =
+                EncryptionUtil.createEncryptionManager(
+                    current().encryptionKeys(), TABLE_PROPERTIES, kmsClient());
+            this.currentFileIO = EncryptingFileIO.combine(plainFileIO, currentEncryption);
+          }
+
+          @Override
+          public TableOperations temp(TableMetadata uncommittedMetadata) {
+            return metadataScopedTemp(this, uncommittedMetadata, plainFileIO);
           }
         };
 
     return TestTables.create(
         dir, name, TestBase.SCHEMA, TestBase.SPEC, SortOrder.unsorted(), 3, ops);
+  }
+
+  private static TableOperations metadataScopedTemp(
+      TableOperations outer, TableMetadata metadata, FileIO plainFileIO) {
+    EncryptionManager encryption =
+        EncryptionUtil.createEncryptionManager(
+            metadata.encryptionKeys(), TABLE_PROPERTIES, kmsClient());
+    FileIO encryptedFileIO = EncryptingFileIO.combine(plainFileIO, encryption);
+
+    return new StaticTableOperations(
+        metadata,
+        encryptedFileIO,
+        LocationProviders.locationsFor(metadata.location(), metadata.properties())) {
+      @Override
+      public EncryptionManager encryption() {
+        return encryption;
+      }
+
+      @Override
+      public String metadataFileLocation(String fileName) {
+        return outer.metadataFileLocation(fileName);
+      }
+
+      @Override
+      public long newSnapshotId() {
+        return outer.newSnapshotId();
+      }
+    };
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -136,31 +136,45 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
   @Override
   public EncryptionManager encryption() {
-    if (encryptionManager != null) {
-      return encryptionManager;
+    if (encryptionManager == null && tableKeyId != null) {
+      encryptionManager = createEncryptionManager(encryptedKeys, tableKeyId, encryptionDekLength);
     }
 
-    if (tableKeyId != null) {
-      Preconditions.checkArgument(
-          keyManagementClient != null,
-          "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
-          CatalogProperties.ENCRYPTION_KMS_IMPL);
+    return encryptionManager != null ? encryptionManager : PlaintextEncryptionManager.instance();
+  }
 
-      Map<String, String> encryptionProperties =
-          ImmutableMap.of(
-              TableProperties.ENCRYPTION_TABLE_KEY,
-              tableKeyId,
-              TableProperties.ENCRYPTION_DEK_LENGTH,
-              String.valueOf(encryptionDekLength));
-
-      encryptionManager =
-          EncryptionUtil.createEncryptionManager(
-              encryptedKeys, encryptionProperties, keyManagementClient);
-    } else {
+  private EncryptionManager encryptionFor(TableMetadata metadata) {
+    // Keep the master-key trust anchor in HMS. All other state must come from the metadata that the
+    // temporary operations represent so transaction updates observe their own staged properties.
+    String encryptionKeyId =
+        tableKeyId != null
+            ? tableKeyId
+            : metadata.property(TableProperties.ENCRYPTION_TABLE_KEY, null);
+    if (encryptionKeyId == null) {
       return PlaintextEncryptionManager.instance();
     }
 
-    return encryptionManager;
+    int dataKeyLength =
+        metadata.propertyAsInt(
+            TableProperties.ENCRYPTION_DEK_LENGTH, TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT);
+    return createEncryptionManager(metadata.encryptionKeys(), encryptionKeyId, dataKeyLength);
+  }
+
+  private EncryptionManager createEncryptionManager(
+      List<EncryptedKey> keys, String encryptionKeyId, int dataKeyLength) {
+    Preconditions.checkArgument(
+        keyManagementClient != null,
+        "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
+        CatalogProperties.ENCRYPTION_KMS_IMPL);
+
+    Map<String, String> encryptionProperties =
+        ImmutableMap.of(
+            TableProperties.ENCRYPTION_TABLE_KEY,
+            encryptionKeyId,
+            TableProperties.ENCRYPTION_DEK_LENGTH,
+            String.valueOf(dataKeyLength));
+
+    return EncryptionUtil.createEncryptionManager(keys, encryptionProperties, keyManagementClient);
   }
 
   @Override
@@ -426,6 +440,9 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   @Override
   public TableOperations temp(TableMetadata uncommittedMetadata) {
     return new TableOperations() {
+      private EncryptionManager tempEncryption = null;
+      private FileIO tempFileIO = null;
+
       @Override
       public TableMetadata current() {
         return uncommittedMetadata;
@@ -454,14 +471,27 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       }
 
       @Override
-      public FileIO io() {
-        HiveTableOperations.this.encryptionPropsFromMetadata(uncommittedMetadata.properties());
-        return HiveTableOperations.this.io();
+      public synchronized FileIO io() {
+        if (tempFileIO == null) {
+          EncryptionManager encryption = encryption();
+          tempFileIO =
+              encryption == PlaintextEncryptionManager.instance()
+                  ? fileIO
+                  : EncryptingFileIO.combine(fileIO, encryption);
+        }
+
+        return tempFileIO;
       }
 
       @Override
-      public EncryptionManager encryption() {
-        return HiveTableOperations.this.encryption();
+      public synchronized EncryptionManager encryption() {
+        // A standard manager copies every retained key, so avoid rebuilding the staged key history
+        // after transaction updates that do not use encryption or file access.
+        if (tempEncryption == null) {
+          tempEncryption = encryptionFor(uncommittedMetadata);
+        }
+
+        return tempEncryption;
       }
 
       @Override

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -298,7 +298,22 @@ public class TestTableEncryption extends CatalogTestBase {
       validationCatalog.invalidateTable(created);
       Table reloaded = validationCatalog.loadTable(created);
       assertThat(reloaded.snapshots()).hasSize(1);
-      assertThat(planSnapshot(reloaded, reloaded.currentSnapshot().snapshotId())).isNotEmpty();
+
+      Snapshot snapshot = reloaded.currentSnapshot();
+      assertThat(snapshot).isNotNull();
+      assertThat(snapshot.keyId()).isNotNull();
+
+      TableMetadata metadata = ((HasTableOperations) reloaded).operations().current();
+      EncryptedKey manifestListKey =
+          metadata.encryptionKeys().stream()
+              .filter(key -> key.keyId().equals(snapshot.keyId()))
+              .findFirst()
+              .orElse(null);
+
+      assertThat(manifestListKey).isNotNull();
+      assertThat(metadata.encryptionKeys())
+          .anyMatch(key -> key.keyId().equals(manifestListKey.encryptedById()));
+      assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
     } finally {
       validationCatalog.dropTable(created);
     }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark.sql;
 
 import static org.apache.iceberg.Files.localInput;
+import static org.apache.iceberg.Files.localOutput;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -52,9 +53,13 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Transaction;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.EncryptedKey;
+import org.apache.iceberg.encryption.NativeEncryptionOutputFile;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
@@ -242,6 +247,78 @@ public class TestTableEncryption extends CatalogTestBase {
     }
 
     assertThat(currentDataFiles(reloaded)).hasSize(initialFiles.size() + 2);
+  }
+
+  @TestTemplate
+  void transactionRebasePreservesManifestListKeys() throws IOException {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    List<DataFile> initialFiles = currentDataFiles(table);
+    int initialSnapshotCount = (int) Streams.stream(table.snapshots()).count();
+    DataFile file = initialFiles.get(0);
+
+    Transaction transaction = table.newTransaction();
+    transaction.newFastAppend().appendFile(file).commit();
+
+    table.newFastAppend().appendFile(file).commit();
+
+    transaction.newFastAppend().appendFile(file).commit();
+    transaction.commitTransaction();
+
+    validationCatalog.invalidateTable(tableIdent);
+    Table reloaded = validationCatalog.loadTable(tableIdent);
+    assertThat(reloaded.snapshots()).hasSize(initialSnapshotCount + 3);
+    for (Snapshot snapshot : reloaded.snapshots()) {
+      assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
+    }
+
+    assertThat(currentDataFiles(reloaded)).hasSize(initialFiles.size() + 3);
+  }
+
+  @TestTemplate
+  void encryptedCreateTransactionUsesStagedMetadata() throws IOException {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table source = validationCatalog.loadTable(tableIdent);
+    DataFile file = currentDataFiles(source).get(0);
+    TableIdentifier created =
+        TableIdentifier.of(tableIdent.namespace(), tableIdent.name() + "_create_transaction");
+
+    try {
+      Transaction transaction =
+          validationCatalog
+              .buildTable(created, source.schema())
+              .withProperty(TableProperties.FORMAT_VERSION, "3")
+              .withProperty(TableProperties.ENCRYPTION_TABLE_KEY, UnitestKMS.MASTER_KEY_NAME1)
+              .createTransaction();
+      transaction.newFastAppend().appendFile(file).commit();
+      transaction.commitTransaction();
+
+      validationCatalog.invalidateTable(created);
+      Table reloaded = validationCatalog.loadTable(created);
+      assertThat(reloaded.snapshots()).hasSize(1);
+      assertThat(planSnapshot(reloaded, reloaded.currentSnapshot().snapshotId())).isNotEmpty();
+    } finally {
+      validationCatalog.dropTable(created);
+    }
+  }
+
+  @TestTemplate
+  void stagedDataKeyLengthControlsTemporaryEncryption() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    TableOperations ops = ((HasTableOperations) table).operations();
+    TableMetadata staged =
+        TableMetadata.buildFrom(ops.current())
+            .setProperties(Map.of(TableProperties.ENCRYPTION_DEK_LENGTH, "32"))
+            .build();
+
+    assertThat(
+            ops.temp(staged)
+                .encryption()
+                .encrypt(localOutput(table.location() + "/staged-data-key-length")))
+        .isInstanceOfSatisfying(
+            NativeEncryptionOutputFile.class,
+            output -> assertThat(output.keyMetadata().encryptionKey().remaining()).isEqualTo(32));
   }
 
   // See CatalogTests#testConcurrentReplaceTransactions

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -271,6 +271,7 @@ public class TestTableEncryption extends CatalogTestBase {
     Table reloaded = validationCatalog.loadTable(tableIdent);
     assertThat(reloaded.snapshots()).hasSize(initialSnapshotCount + 3);
     for (Snapshot snapshot : reloaded.snapshots()) {
+      assertSnapshotHasEncryptionKeys(reloaded, snapshot);
       assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
     }
 
@@ -301,18 +302,7 @@ public class TestTableEncryption extends CatalogTestBase {
 
       Snapshot snapshot = reloaded.currentSnapshot();
       assertThat(snapshot).isNotNull();
-      assertThat(snapshot.keyId()).isNotNull();
-
-      TableMetadata metadata = ((HasTableOperations) reloaded).operations().current();
-      EncryptedKey manifestListKey =
-          metadata.encryptionKeys().stream()
-              .filter(key -> key.keyId().equals(snapshot.keyId()))
-              .findFirst()
-              .orElse(null);
-
-      assertThat(manifestListKey).isNotNull();
-      assertThat(metadata.encryptionKeys())
-          .anyMatch(key -> key.keyId().equals(manifestListKey.encryptedById()));
+      assertSnapshotHasEncryptionKeys(reloaded, snapshot);
       assertThat(planSnapshot(reloaded, snapshot.snapshotId())).isNotEmpty();
     } finally {
       validationCatalog.dropTable(created);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -59,7 +59,9 @@ import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.encryption.Ciphers;
 import org.apache.iceberg.encryption.EncryptedKey;
+import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.NativeEncryptionOutputFile;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
@@ -319,6 +321,36 @@ public class TestTableEncryption extends CatalogTestBase {
         .isInstanceOfSatisfying(
             NativeEncryptionOutputFile.class,
             output -> assertThat(output.keyMetadata().encryptionKey().remaining()).isEqualTo(32));
+  }
+
+  @TestTemplate
+  void catalogMasterKeyControlsTemporaryEncryption() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+    TableOperations ops = ((HasTableOperations) table).operations();
+    TableMetadata staged =
+        TableMetadata.buildFrom(ops.current())
+            .setProperties(
+                Map.of(TableProperties.ENCRYPTION_TABLE_KEY, UnitestKMS.MASTER_KEY_NAME2))
+            .build();
+
+    assertThat(ops.temp(staged).encryption())
+        .isInstanceOfSatisfying(
+            StandardEncryptionManager.class,
+            encryption -> {
+              NativeEncryptionOutputFile output =
+                  encryption.encrypt(
+                      localOutput(table.location() + "/catalog-master-key-precedence"));
+              String manifestListKeyId =
+                  encryption.addManifestListKeyMetadata(output.keyMetadata());
+              Map<String, EncryptedKey> keys = EncryptionUtil.encryptionKeys(encryption);
+              EncryptedKey manifestListKey = keys.get(manifestListKeyId);
+
+              assertThat(manifestListKey).isNotNull();
+              EncryptedKey keyEncryptionKey = keys.get(manifestListKey.encryptedById());
+              assertThat(keyEncryptionKey).isNotNull();
+              assertThat(keyEncryptionKey.encryptedById()).isEqualTo(UnitestKMS.MASTER_KEY_NAME1);
+            });
   }
 
   // See CatalogTests#testConcurrentReplaceTransactions


### PR DESCRIPTION
## Why this PR is required

#27 fixes direct concurrent commits by persisting each snapshot's linked keys, but it also removes
Hive's refresh-time carry-forward of manager-only keys. That exposes two existing temporary-
operation problems: Hive temporary operations delegate encryption to mutable outer state, and
`BaseTransaction` does not replace temporary operations before replay after adopting a refreshed
base.

The result is a deterministic encrypted-transaction regression on #27. This PR is not needed to
make #27's direct concurrent-append test pass, but it must merge before any release containing #27.
The three PRs are intentionally stacked for review and form one release unit.

## Immediate-base evidence

These are the measured results with this PR's tests applied directly to #27:

| Test | #27 | This PR | What it proves |
| --- | --- | --- | --- |
| Spark `transactionRebasePreservesManifestListKeys` | **Fails:** missing staged-parent key in `FastAppend.apply` | Passes | A second staged append survives an interleaved direct commit |
| Core `transactionRebasePreservesManifestListKeys` | **Fails:** replay cannot read the adopted parent | Passes | Temporary operations are reset before replay |
| Spark `stagedDataKeyLengthControlsTemporaryEncryption` | **Fails:** 16 bytes instead of staged 32 | Passes | Temporary encryption uses staged properties |
| Spark `encryptedCreateTransactionUsesStagedMetadata` | Passes | Passes | Encrypted creation retains its MLK, KEK, and readable snapshot |
| Spark `catalogMasterKeyControlsTemporaryEncryption` | Passes | Passes | Existing tables keep catalog master-key precedence |

The first Spark test also passes on `main`; its failure is specifically exposed by #27. The final
two rows are behavior-preservation coverage, not evidence of additional baseline failures.

## Root cause

Hive's `temp(metadata)` operations represent one staged `TableMetadata`, but their `encryption()`
and `io()` methods delegated to the mutable outer `HiveTableOperations`. An interleaved direct
commit refreshes that outer state and drops the transaction-only key needed to read the staged
parent snapshot. The same delegation uses a cached 16-byte manager even when staged metadata
requests a 32-byte DEK.

Separately, transaction rebase replaces `current` with refreshed metadata and replays pending
updates. Reusing temporary operations for the previous staged base makes replay read through stale
encryption state.

## Change

- Rebuild transaction temporary operations immediately after adopting refreshed metadata and before
  replaying pending updates.
- Build Hive temporary encryption and `FileIO` lazily from the wrapped keys and encryption
  properties in the exact staged metadata represented by those operations.
- Prefer the catalog-sourced master-key ID for an existing table. Fall back to the staged metadata
  key only for create transactions, before a catalog entry exists.
- Keep temporary state isolated from the outer operations object. No public API changes are added.

## Trust and scope

The catalog remains the trust anchor for existing tables. The pass/pass precedence test supplies a
conflicting staged key and proves that the catalog key still wraps the KEK. The create-transaction
test now rejects a plaintext false positive by requiring a snapshot key ID, its MLK and KEK in
metadata, and a plannable snapshot.

This is PR 3 of 3. It preserves staged encrypted transactions after #27; it does not change the
direct concurrency diagnosis.

---
**AI Disclosure**
- Model: OpenAI GPT-5 Codex
- Platform/Tool: OpenAI Codex
- Human Oversight: partially reviewed
- Prompt Summary: Preserve staged Hive encryption state and transaction replay behavior required by the preceding snapshot-key persistence PR.
