### PR TITLE
Core: Fix time travel filter when the schema changes without a new snapshot

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -82,7 +82,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
 
   protected Map<Integer, PartitionSpec> specs() {
     Map<Integer, PartitionSpec> specs = table().specs();
-    // requires latest schema
+    // the table's specs are already bound to the scan's schema
     if (!useSnapshotSchema()
         || snapshotId() == null
         || tableSchema().sameSchema(table().schema())) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -85,8 +85,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
     // requires latest schema
     if (!useSnapshotSchema()
         || snapshotId() == null
-        || table().currentSnapshot() == null
-        || snapshotId().equals(table().currentSnapshot().snapshotId())) {
+        || tableSchema().sameSchema(table().schema())) {
       return specs;
     }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.DateTimeUtil;
+import org.apache.iceberg.util.JsonUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,26 @@ import org.slf4j.LoggerFactory;
 public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     extends BaseScan<ThisT, T, G> {
 
+  /**
+   * Controls whether an exact snapshot scan uses the snapshot schema.
+   *
+   * <p>Accepted values are {@code true} and {@code false}; the default is {@code true}. A false
+   * value retains the scan's schema. This option must be set before {@link #useSnapshot(long)} and
+   * cannot be combined with a non-main {@link #useRef(String)} or {@link #asOfTime(long)}.
+   */
+  public static final String USE_SNAPSHOT_SCHEMA = "use-snapshot-schema";
+
+  /**
+   * Supplies the schema retained by an exact snapshot scan.
+   *
+   * <p>The value must be a schema JSON object with a schema ID and can only be used when {@link
+   * #USE_SNAPSHOT_SCHEMA} is {@code false}. This option must be set before {@link
+   * #useSnapshot(long)} and cannot be combined with a non-main {@link #useRef(String)} or {@link
+   * #asOfTime(long)}.
+   */
+  public static final String SCAN_SCHEMA = "scan-schema";
+
+  private static final boolean USE_SNAPSHOT_SCHEMA_DEFAULT = true;
   private static final Logger LOG = LoggerFactory.getLogger(SnapshotScan.class);
 
   private ScanMetrics scanMetrics;
@@ -72,6 +93,13 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
     return false;
   }
 
+  protected boolean shouldUseSnapshotSchema() {
+    String value = options().get(USE_SNAPSHOT_SCHEMA);
+    boolean configuredValue =
+        value != null ? Boolean.parseBoolean(value) : USE_SNAPSHOT_SCHEMA_DEFAULT;
+    return useSnapshotSchema() && configuredValue;
+  }
+
   protected ScanMetrics scanMetrics() {
     if (scanMetrics == null) {
       this.scanMetrics = ScanMetrics.of(new DefaultMetricsContext());
@@ -89,7 +117,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
       return specs;
     }
 
-    // this is a time travel request
+    // bind specs to the schema retained by this scan
     Schema snapshotSchema = tableSchema();
     ImmutableMap.Builder<Integer, PartitionSpec> newSpecs =
         ImmutableMap.builderWithExpectedSize(specs.size());
@@ -107,8 +135,20 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
         table().snapshot(scanSnapshotId) != null,
         "Cannot find snapshot with ID %s",
         scanSnapshotId);
+
+    Schema configuredScanSchema = configuredScanSchema();
+    if (configuredScanSchema != null) {
+      Preconditions.checkArgument(
+          "false".equalsIgnoreCase(options().get(USE_SNAPSHOT_SCHEMA)),
+          "Cannot use scan option %s unless scan option %s is false",
+          SCAN_SCHEMA,
+          USE_SNAPSHOT_SCHEMA);
+    }
+
     Schema newSchema =
-        useSnapshotSchema() ? SnapshotUtil.schemaFor(table(), scanSnapshotId) : tableSchema();
+        shouldUseSnapshotSchema()
+            ? SnapshotUtil.schemaFor(table(), scanSnapshotId)
+            : scanSchema(configuredScanSchema);
     TableScanContext newContext = context().useSnapshotId(scanSnapshotId);
     return newRefinedScan(table(), newSchema, newContext);
   }
@@ -117,6 +157,12 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
     if (SnapshotRef.MAIN_BRANCH.equals(name)) {
       return newRefinedScan(table(), tableSchema(), context());
     }
+
+    String exactSnapshotOption = exactSnapshotOption();
+    Preconditions.checkArgument(
+        exactSnapshotOption == null,
+        "Cannot use non-main ref when scan option %s is set",
+        exactSnapshotOption);
 
     Preconditions.checkArgument(
         snapshotId() == null, "Cannot override ref, already set snapshot id=%s", snapshotId());
@@ -128,10 +174,81 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
   }
 
   public ThisT asOfTime(long timestampMillis) {
+    String exactSnapshotOption = exactSnapshotOption();
+    Preconditions.checkArgument(
+        exactSnapshotOption == null,
+        "Cannot use timestamp when scan option %s is set",
+        exactSnapshotOption);
     Preconditions.checkArgument(
         snapshotId() == null, "Cannot override snapshot, already set snapshot id=%s", snapshotId());
 
     return useSnapshot(SnapshotUtil.snapshotIdAsOfTime(table(), timestampMillis));
+  }
+
+  @Override
+  public ThisT option(String property, String value) {
+    if (USE_SNAPSHOT_SCHEMA.equals(property) || SCAN_SCHEMA.equals(property)) {
+      Preconditions.checkArgument(
+          snapshotId() == null,
+          "Cannot set scan option %s, snapshot already set to id=%s",
+          property,
+          snapshotId());
+    }
+
+    if (USE_SNAPSHOT_SCHEMA.equals(property)) {
+      Preconditions.checkArgument(
+          value != null && ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)),
+          "Invalid value for scan option %s: %s (must be true or false)",
+          USE_SNAPSHOT_SCHEMA,
+          value);
+    }
+
+    if (SCAN_SCHEMA.equals(property)) {
+      Preconditions.checkArgument(
+          value != null, "Invalid value for scan option %s: null", property);
+    }
+
+    return super.option(property, value);
+  }
+
+  private String exactSnapshotOption() {
+    if (options().containsKey(USE_SNAPSHOT_SCHEMA)) {
+      return USE_SNAPSHOT_SCHEMA;
+    } else if (options().containsKey(SCAN_SCHEMA)) {
+      return SCAN_SCHEMA;
+    }
+
+    return null;
+  }
+
+  private Schema configuredScanSchema() {
+    String schemaJson = options().get(SCAN_SCHEMA);
+    if (schemaJson == null) {
+      return null;
+    }
+
+    return JsonUtil.parse(
+        schemaJson,
+        json -> {
+          Preconditions.checkArgument(
+              json.hasNonNull("schema-id"), "Invalid scan schema: missing schema-id");
+          return SchemaParser.fromJson(json);
+        });
+  }
+
+  private Schema scanSchema(Schema configuredScanSchema) {
+    if (configuredScanSchema == null) {
+      return tableSchema();
+    }
+
+    Schema knownSchema = table().schemas().get(configuredScanSchema.schemaId());
+    Preconditions.checkArgument(
+        knownSchema != null, "Cannot find scan schema with ID %s", configuredScanSchema.schemaId());
+    Preconditions.checkArgument(
+        knownSchema.sameSchema(configuredScanSchema),
+        "Scan schema with ID %s does not match the table schema with that ID",
+        configuredScanSchema.schemaId());
+    return knownSchema;
   }
 
   @Override
@@ -162,6 +279,7 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
         () -> {
           planningDuration.stop();
           Map<String, String> metadata = Maps.newHashMap(context().options());
+          metadata.remove(SCAN_SCHEMA);
           metadata.putAll(EnvironmentContext.get());
           ScanReport scanReport =
               ImmutableScanReport.builder()

--- a/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseRewriteDataFilesAction.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.encryption.EncryptionManager;
@@ -228,6 +229,7 @@ public abstract class BaseRewriteDataFilesAction<ThisT>
       fileScanTasks =
           table
               .newScan()
+              .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString())
               .useSnapshot(startingSnapshotId)
               .caseSensitive(caseSensitive)
               .ignoreResiduals()

--- a/core/src/main/java/org/apache/iceberg/actions/BinPackRewriteFilePlanner.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BinPackRewriteFilePlanner.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.RewriteJobOrder;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -96,6 +97,7 @@ public class BinPackRewriteFilePlanner
   private final Expression filter;
   private final Long snapshotId;
   private final boolean caseSensitive;
+  private final boolean useSnapshotSchema;
 
   private int deleteFileThreshold;
   private double deleteRatioThreshold;
@@ -111,6 +113,7 @@ public class BinPackRewriteFilePlanner
         table,
         filter,
         table.currentSnapshot() != null ? table.currentSnapshot().snapshotId() : null,
+        false,
         false);
   }
 
@@ -125,10 +128,30 @@ public class BinPackRewriteFilePlanner
    */
   public BinPackRewriteFilePlanner(
       Table table, Expression filter, Long snapshotId, boolean caseSensitive) {
+    this(table, filter, snapshotId, caseSensitive, true);
+  }
+
+  /**
+   * Creates the planner for the given table.
+   *
+   * @param table to plan for
+   * @param filter used to remove files from the plan
+   * @param snapshotId a snapshot ID used for planning and as the starting snapshot id for commit
+   *     validation when replacing the files
+   * @param caseSensitive property used for scanning
+   * @param useSnapshotSchema whether to use the snapshot schema instead of the table schema
+   */
+  public BinPackRewriteFilePlanner(
+      Table table,
+      Expression filter,
+      Long snapshotId,
+      boolean caseSensitive,
+      boolean useSnapshotSchema) {
     super(table);
     this.filter = filter;
     this.snapshotId = snapshotId;
     this.caseSensitive = caseSensitive;
+    this.useSnapshotSchema = useSnapshotSchema;
   }
 
   @Override
@@ -291,6 +314,10 @@ public class BinPackRewriteFilePlanner
         table().newScan().filter(filter).caseSensitive(caseSensitive).ignoreResiduals();
 
     if (snapshotId != null) {
+      if (!useSnapshotSchema) {
+        scan = scan.option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString());
+      }
+
       scan = scan.useSnapshot(snapshotId);
     }
 

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -56,6 +56,8 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RetryableValidationException;
 import org.apache.iceberg.Scan;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
@@ -842,7 +844,26 @@ public class CatalogHandlers {
       TableScan tableScan = table.newScan();
 
       if (request.snapshotId() != null) {
+        Schema expectedScanSchema = null;
+        if (!request.useSnapshotSchema()) {
+          expectedScanSchema =
+              request.scanSchema() != null ? request.scanSchema() : tableScan.schema();
+          tableScan = tableScan.option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString());
+          if (request.scanSchema() != null) {
+            validateScanSchema(table, request.scanSchema());
+            tableScan =
+                tableScan.option(
+                    SnapshotScan.SCAN_SCHEMA, SchemaParser.toJson(request.scanSchema()));
+          }
+        }
         tableScan = tableScan.useSnapshot(request.snapshotId());
+        if (expectedScanSchema != null) {
+          Preconditions.checkArgument(
+              matchesSchema(tableScan.schema(), expectedScanSchema),
+              "Scan %s did not use requested scan schema with ID %s",
+              tableScan.getClass().getName(),
+              expectedScanSchema.schemaId());
+        }
       }
 
       // Apply filters and projections using common method
@@ -881,7 +902,7 @@ public class CatalogHandlers {
             .withPlanStatus(PlanStatus.COMPLETED)
             .withPlanId(planId)
             .withFileScanTasks(initial.first())
-            .withSpecsById(table.specs());
+            .withSpecsById(specsForTasks(table, initial.first()));
 
     if (!nextPlanTasks.isEmpty()) {
       builder.withPlanTasks(nextPlanTasks);
@@ -911,7 +932,7 @@ public class CatalogHandlers {
         .withPlanStatus(PlanStatus.COMPLETED)
         .withFileScanTasks(initial.first())
         .withPlanTasks(IN_MEMORY_PLANNING_STATE.nextPlanTask(initial.second()))
-        .withSpecsById(table.specs())
+        .withSpecsById(specsForTasks(table, initial.first()))
         .build();
   }
 
@@ -932,8 +953,38 @@ public class CatalogHandlers {
     return FetchScanTasksResponse.builder()
         .withFileScanTasks(fileScanTasks)
         .withPlanTasks(IN_MEMORY_PLANNING_STATE.nextPlanTask(planTask))
-        .withSpecsById(table.specs())
+        .withSpecsById(specsForTasks(table, fileScanTasks))
         .build();
+  }
+
+  private static Map<Integer, PartitionSpec> specsForTasks(Table table, List<FileScanTask> tasks) {
+    if (tasks.isEmpty()) {
+      return table.specs();
+    }
+
+    Schema taskSchema = tasks.get(0).spec().schema();
+    if (taskSchema.sameSchema(table.schema())) {
+      return table.specs();
+    }
+
+    return table.specs().entrySet().stream()
+        .collect(
+            Collectors.toMap(
+                Map.Entry::getKey, entry -> entry.getValue().toUnbound().bind(taskSchema, true)));
+  }
+
+  private static void validateScanSchema(Table table, Schema scanSchema) {
+    Schema knownSchema = table.schemas().get(scanSchema.schemaId());
+    Preconditions.checkArgument(
+        knownSchema != null, "Cannot find scan schema with ID %s", scanSchema.schemaId());
+    Preconditions.checkArgument(
+        matchesSchema(knownSchema, scanSchema),
+        "Scan schema with ID %s does not match the table schema with that ID",
+        scanSchema.schemaId());
+  }
+
+  private static boolean matchesSchema(Schema left, Schema right) {
+    return left.schemaId() == right.schemaId() && left.sameSchema(right);
   }
 
   /**
@@ -1030,6 +1081,13 @@ public class CatalogHandlers {
 
         previousPlanTask = planTaskKey;
       }
+
+      if (initialFileScanTasks == null) {
+        firstPlanTaskKey = planTaskPrefix + "0";
+        initialFileScanTasks = Collections.emptyList();
+        IN_MEMORY_PLANNING_STATE.addPlanTask(firstPlanTaskKey, initialFileScanTasks);
+      }
+
       return Pair.of(initialFileScanTasks, firstPlanTaskKey);
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -82,7 +82,6 @@ class RESTTableScan extends DataTableScan {
   private final ResourcePaths resourcePaths;
   private final TableIdentifier tableIdentifier;
   private final Set<Endpoint> supportedEndpoints;
-  private final ParserContext parserContext;
   private final Map<String, String> catalogProperties;
   private final Object hadoopConf;
   private String planId = null;
@@ -108,11 +107,6 @@ class RESTTableScan extends DataTableScan {
     this.tableIdentifier = tableIdentifier;
     this.resourcePaths = resourcePaths;
     this.supportedEndpoints = supportedEndpoints;
-    this.parserContext =
-        ParserContext.builder()
-            .add("specsById", table.specs())
-            .add("caseSensitive", context().caseSensitive())
-            .build();
     this.catalogProperties = catalogProperties;
     this.hadoopConf = hadoopConf;
   }
@@ -140,14 +134,17 @@ class RESTTableScan extends DataTableScan {
   @Override
   public TableScan useRef(String name) {
     SnapshotRef ref = table().refs().get(name);
-    this.useSnapshotSchema = ref != null && ref.isTag();
-    return super.useRef(name);
+    RESTTableScan scan = (RESTTableScan) super.useRef(name);
+    scan.useSnapshotSchema = ref != null && ref.isTag();
+    return scan;
   }
 
   @Override
   public TableScan useSnapshot(long snapshotId) {
-    this.useSnapshotSchema = true;
-    return super.useSnapshot(snapshotId);
+    boolean shouldUseSnapshotSchema = shouldUseSnapshotSchema();
+    RESTTableScan scan = (RESTTableScan) super.useSnapshot(snapshotId);
+    scan.useSnapshotSchema = shouldUseSnapshotSchema;
+    return scan;
   }
 
   @Override
@@ -191,6 +188,9 @@ class RESTTableScan extends DataTableScan {
           .withUseSnapshotSchema(true);
     } else if (snapshotId != null) {
       builder.withSnapshotId(snapshotId).withUseSnapshotSchema(useSnapshotSchema);
+      if (!useSnapshotSchema) {
+        builder.withScanSchema(tableSchema());
+      }
     }
 
     return planTableScan(builder.build());
@@ -205,7 +205,7 @@ class RESTTableScan extends DataTableScan {
             headers,
             ErrorHandlers.tableErrorHandler(),
             stringStringMap -> {},
-            parserContext);
+            parserContext());
 
     this.planId = response.planId();
     PlanStatus planStatus = response.planStatus();
@@ -279,7 +279,7 @@ class RESTTableScan extends DataTableScan {
                         FetchPlanningResultResponse.class,
                         headers,
                         ErrorHandlers.planErrorHandler(),
-                        parserContext);
+                        parserContext());
 
                 switch (response.planStatus()) {
                   case COMPLETED:
@@ -352,8 +352,15 @@ class RESTTableScan extends DataTableScan {
             tableIdentifier,
             headers,
             planExecutor(),
-            parserContext),
+            parserContext()),
         this::cancelPlan);
+  }
+
+  private ParserContext parserContext() {
+    return ParserContext.builder()
+        .add("specsById", specs())
+        .add("caseSensitive", isCaseSensitive())
+        .build();
   }
 
   /** Cancels the plan on the server (if supported) and closes the plan-scoped FileIO */

--- a/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequest.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest.requests;
 
 import java.util.List;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -30,6 +31,7 @@ public class PlanTableScanRequest implements RESTRequest {
   private final Expression filter;
   private final boolean caseSensitive;
   private final boolean useSnapshotSchema;
+  private final Schema scanSchema;
   private final Long startSnapshotId;
   private final Long endSnapshotId;
   private final List<String> statsFields;
@@ -55,6 +57,10 @@ public class PlanTableScanRequest implements RESTRequest {
     return useSnapshotSchema;
   }
 
+  public Schema scanSchema() {
+    return scanSchema;
+  }
+
   public Long startSnapshotId() {
     return startSnapshotId;
   }
@@ -77,6 +83,7 @@ public class PlanTableScanRequest implements RESTRequest {
       Expression filter,
       boolean caseSensitive,
       boolean useSnapshotSchema,
+      Schema scanSchema,
       Long startSnapshotId,
       Long endSnapshotId,
       List<String> statsFields,
@@ -86,6 +93,7 @@ public class PlanTableScanRequest implements RESTRequest {
     this.filter = filter;
     this.caseSensitive = caseSensitive;
     this.useSnapshotSchema = useSnapshotSchema;
+    this.scanSchema = scanSchema;
     this.startSnapshotId = startSnapshotId;
     this.endSnapshotId = endSnapshotId;
     this.statsFields = statsFields;
@@ -107,6 +115,14 @@ public class PlanTableScanRequest implements RESTRequest {
           "Invalid incremental scan: startSnapshotId and endSnapshotId is required");
     }
 
+    if (scanSchema != null) {
+      Preconditions.checkArgument(
+          snapshotId != null, "Invalid scan: scanSchema requires snapshotId");
+      Preconditions.checkArgument(
+          !useSnapshotSchema,
+          "Invalid scan: scanSchema cannot be used when useSnapshotSchema is true");
+    }
+
     if (null != minRowsRequested) {
       Preconditions.checkArgument(
           minRowsRequested >= 0L, "Invalid scan: minRowsRequested is negative");
@@ -121,6 +137,7 @@ public class PlanTableScanRequest implements RESTRequest {
         .add("filter", filter)
         .add("caseSensitive", caseSensitive)
         .add("useSnapshotSchema", useSnapshotSchema)
+        .add("scanSchema", scanSchema)
         .add("startSnapshotId", startSnapshotId)
         .add("endSnapshotId", endSnapshotId)
         .add("statsFields", statsFields)
@@ -138,6 +155,7 @@ public class PlanTableScanRequest implements RESTRequest {
     private Expression filter;
     private boolean caseSensitive = true;
     private boolean useSnapshotSchema = false;
+    private Schema scanSchema;
     private Long startSnapshotId;
     private Long endSnapshotId;
     private List<String> statsFields;
@@ -175,6 +193,11 @@ public class PlanTableScanRequest implements RESTRequest {
       return this;
     }
 
+    public Builder withScanSchema(Schema schema) {
+      this.scanSchema = schema;
+      return this;
+    }
+
     public Builder withStartSnapshotId(Long startingSnapshotId) {
       this.startSnapshotId = startingSnapshotId;
       return this;
@@ -202,6 +225,7 @@ public class PlanTableScanRequest implements RESTRequest {
           filter,
           caseSensitive,
           useSnapshotSchema,
+          scanSchema,
           startSnapshotId,
           endSnapshotId,
           statsFields,

--- a/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/PlanTableScanRequestParser.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -33,6 +35,7 @@ public class PlanTableScanRequestParser {
   private static final String FILTER = "filter";
   private static final String CASE_SENSITIVE = "case-sensitive";
   private static final String USE_SNAPSHOT_SCHEMA = "use-snapshot-schema";
+  private static final String SCAN_SCHEMA = "scan-schema";
   private static final String START_SNAPSHOT_ID = "start-snapshot-id";
   private static final String END_SNAPSHOT_ID = "end-snapshot-id";
   private static final String STATS_FIELDS = "stats-fields";
@@ -86,6 +89,11 @@ public class PlanTableScanRequestParser {
     gen.writeBooleanField(CASE_SENSITIVE, request.caseSensitive());
     gen.writeBooleanField(USE_SNAPSHOT_SCHEMA, request.useSnapshotSchema());
 
+    if (request.scanSchema() != null) {
+      gen.writeFieldName(SCAN_SCHEMA);
+      SchemaParser.toJson(request.scanSchema(), gen);
+    }
+
     if (request.statsFields() != null && !request.statsFields().isEmpty()) {
       JsonUtil.writeStringArray(STATS_FIELDS, request.statsFields(), gen);
     }
@@ -128,6 +136,15 @@ public class PlanTableScanRequestParser {
       useSnapshotSchema = JsonUtil.getBool(USE_SNAPSHOT_SCHEMA, json);
     }
 
+    Schema scanSchema = null;
+    if (json.has(SCAN_SCHEMA)) {
+      JsonNode scanSchemaJson = JsonUtil.get(SCAN_SCHEMA, json);
+      Preconditions.checkArgument(
+          scanSchemaJson.hasNonNull("schema-id"),
+          "Cannot parse scan-schema: missing required field schema-id");
+      scanSchema = SchemaParser.fromJson(scanSchemaJson);
+    }
+
     List<String> statsFields = JsonUtil.getStringListOrNull(STATS_FIELDS, json);
 
     return PlanTableScanRequest.builder()
@@ -136,6 +153,7 @@ public class PlanTableScanRequestParser {
         .withFilter(filter)
         .withCaseSensitive(caseSensitive)
         .withUseSnapshotSchema(useSnapshotSchema)
+        .withScanSchema(scanSchema)
         .withStartSnapshotId(startSnapshotId)
         .withEndSnapshotId(endSnapshotId)
         .withStatsFields(statsFields)

--- a/core/src/test/java/org/apache/iceberg/DataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DataTableScanTestBase.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -179,6 +180,191 @@ public abstract class DataTableScanTestBase<
     assertThatThrownBy(() -> useRef(newScan(), "nonexisting"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot find ref nonexisting");
+  }
+
+  @TestTemplate
+  public void exactSnapshotPinPlansWithCurrentSchema() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    ScanT scan =
+        useSnapshot(newScan().option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"), snapshotId)
+            .filter(Expressions.notNull("renamed_data"));
+    assertThat(scan.schema()).isEqualTo(table.schema());
+    validateExpectedFileScanTasks(scan, ImmutableList.of(FILE_A.location()));
+  }
+
+  @TestTemplate
+  public void exactSnapshotPinRemainsOnCapturedSnapshot() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    ScanT scan =
+        useSnapshot(newScan().option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"), snapshotId);
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+
+    validateExpectedFileScanTasks(scan, ImmutableList.of(FILE_A.location()));
+  }
+
+  @TestTemplate
+  public void exactSnapshotPinRetainsSchemaAfterTableSchemaChange() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    Schema pinnedSchema = table.schema();
+    ScanT scan =
+        useSnapshot(newScan().option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"), snapshotId)
+            .filter(Expressions.notNull("data"));
+
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    assertThat(scan.schema()).isEqualTo(pinnedSchema);
+    validateExpectedFileScanTasks(scan, ImmutableList.of(FILE_A.location()));
+  }
+
+  @TestTemplate
+  public void exactSnapshotPinUsesCapturedScanSchemaInEitherOptionOrder() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "captured_data").commit();
+    Schema capturedSchema = table.schema();
+    String capturedSchemaJson = SchemaParser.toJson(capturedSchema);
+    table.updateSchema().renameColumn("captured_data", "latest_data").commit();
+
+    ScanT schemaFirst =
+        useSnapshot(
+                newScan()
+                    .option(SnapshotScan.SCAN_SCHEMA, capturedSchemaJson)
+                    .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"),
+                snapshotId)
+            .filter(Expressions.notNull("captured_data"));
+    ScanT selectionFirst =
+        useSnapshot(
+                newScan()
+                    .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false")
+                    .option(SnapshotScan.SCAN_SCHEMA, capturedSchemaJson),
+                snapshotId)
+            .filter(Expressions.notNull("captured_data"));
+
+    assertThat(schemaFirst.schema()).isEqualTo(capturedSchema);
+    assertThat(selectionFirst.schema()).isEqualTo(capturedSchema);
+    validateExpectedFileScanTasks(schemaFirst, ImmutableList.of(FILE_A.location()));
+    validateExpectedFileScanTasks(selectionFirst, ImmutableList.of(FILE_A.location()));
+  }
+
+  @TestTemplate
+  public void exactSnapshotScanSchemaRequiresCurrentSchemaSelection() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    String schemaJson = SchemaParser.toJson(table.schema());
+
+    assertThatThrownBy(
+            () -> useSnapshot(newScan().option(SnapshotScan.SCAN_SCHEMA, schemaJson), snapshotId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot use scan option scan-schema unless scan option use-snapshot-schema is false");
+  }
+
+  @TestTemplate
+  public void exactSnapshotScanSchemaRequiresSchemaId() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+
+    assertThatThrownBy(
+            () ->
+                useSnapshot(
+                    newScan()
+                        .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false")
+                        .option(SnapshotScan.SCAN_SCHEMA, "{\"type\":\"struct\",\"fields\":[]}"),
+                    snapshotId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid scan schema: missing schema-id");
+  }
+
+  @TestTemplate
+  public void exactSnapshotSchemaOptionRejectsInvalidValue() {
+    assertThatThrownBy(() -> newScan().option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "invalid"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid value for scan option use-snapshot-schema: invalid (must be true or false)");
+  }
+
+  @TestTemplate
+  public void exactSnapshotSchemaOptionMustPrecedeSnapshot() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    ScanT scan = useSnapshot(newScan(), table.currentSnapshot().snapshotId());
+
+    assertThatThrownBy(() -> scan.option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot set scan option use-snapshot-schema, snapshot already set to id=1");
+    assertThatThrownBy(
+            () -> scan.option(SnapshotScan.SCAN_SCHEMA, SchemaParser.toJson(table.schema())))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot set scan option scan-schema, snapshot already set to id=1");
+  }
+
+  @TestTemplate
+  public void exactSnapshotSchemaOptionCannotBeUsedWithRef() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.manageSnapshots().createBranch("branch", table.currentSnapshot().snapshotId()).commit();
+
+    assertThatThrownBy(
+            () -> useRef(newScan().option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"), "branch"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot use non-main ref when scan option use-snapshot-schema is set");
+    assertThatThrownBy(
+            () -> useRef(newScan(), "branch").option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot set scan option use-snapshot-schema, snapshot already set to id=1");
+    assertThatThrownBy(
+            () ->
+                useRef(
+                    newScan().option(SnapshotScan.SCAN_SCHEMA, SchemaParser.toJson(table.schema())),
+                    "branch"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot use non-main ref when scan option scan-schema is set");
+  }
+
+  @TestTemplate
+  public void exactSnapshotSchemaOptionCannotBeUsedWithTimestamp() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    assertThatThrownBy(
+            () ->
+                asOfTime(
+                    newScan().option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"),
+                    System.currentTimeMillis()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot use timestamp when scan option use-snapshot-schema is set");
+    assertThatThrownBy(
+            () ->
+                asOfTime(
+                    newScan().option(SnapshotScan.SCAN_SCHEMA, SchemaParser.toJson(table.schema())),
+                    System.currentTimeMillis()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot use timestamp when scan option scan-schema is set");
+  }
+
+  @TestTemplate
+  public void mainRefCanBeCombinedWithExactSnapshotSchemaOption() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+
+    ScanT optionBeforeRef =
+        useSnapshot(
+            useRef(
+                newScan().option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"),
+                SnapshotRef.MAIN_BRANCH),
+            snapshotId);
+    ScanT refBeforeOption =
+        useSnapshot(
+            useRef(newScan(), SnapshotRef.MAIN_BRANCH)
+                .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false"),
+            snapshotId);
+
+    validateExpectedFileScanTasks(optionBeforeRef, ImmutableList.of(FILE_A.location()));
+    validateExpectedFileScanTasks(refBeforeOption, ImmutableList.of(FILE_A.location()));
   }
 
   private void validateExpectedFileScanTasks(ScanT scan, List<CharSequence> expectedFileScanPaths)

--- a/core/src/test/java/org/apache/iceberg/TestLocalScanPlanningAndReporting.java
+++ b/core/src/test/java/org/apache/iceberg/TestLocalScanPlanningAndReporting.java
@@ -18,11 +18,49 @@
  */
 package org.apache.iceberg;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.ScanReport;
+import org.junit.jupiter.api.TestTemplate;
+
 public class TestLocalScanPlanningAndReporting
     extends ScanPlanningAndReportingTestBase<TableScan, FileScanTask, CombinedScanTask> {
 
   @Override
   protected TableScan newScan(Table table) {
     return table.newScan();
+  }
+
+  @TestTemplate
+  void scanSchemaIsNotReportedInMetadata() throws IOException {
+    TestMetricsReporter reporter = new TestMetricsReporter();
+    Table table =
+        TestTables.create(
+            tableDir,
+            "scan-schema-reporting",
+            SCHEMA,
+            SPEC,
+            SortOrder.unsorted(),
+            formatVersion,
+            reporter);
+    table.newAppend().appendFile(FILE_A).commit();
+
+    TableScan scan =
+        table
+            .newScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false")
+            .option(SnapshotScan.SCAN_SCHEMA, SchemaParser.toJson(table.schema()))
+            .option("reported-option", "reported-value")
+            .useSnapshot(table.currentSnapshot().snapshotId());
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      tasks.forEach(task -> {});
+    }
+
+    ScanReport report = reporter.lastReport();
+    assertThat(report.metadata())
+        .containsEntry("reported-option", "reported-value")
+        .doesNotContainKey(SnapshotScan.SCAN_SCHEMA);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -318,6 +318,27 @@ public class TestScansAndSchemaEvolution {
   }
 
   @TestTemplate
+  public void testColumnDropWithoutNewSnapshot() throws IOException {
+    Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);
+
+    table.newAppend().appendFile(createDataFile("one")).appendFile(createDataFile("two")).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+
+    // drop a column without committing a snapshot, so the table's snapshot still uses the old
+    // schema while the table itself uses the new one
+    table.updateSchema().deleteColumn("data").commit();
+
+    List<FileScanTask> tasks =
+        Lists.newArrayList(
+            table
+                .newScan()
+                .useSnapshot(snapshotId)
+                .filter(Expressions.equal("data", "xyz"))
+                .planFiles());
+    assertThat(tasks).hasSize(2);
+  }
+
+  @TestTemplate
   public void testAddColumnWithDefaultValueAndQuery() throws IOException {
     assumeThat(V3_AND_ABOVE).as("Default values require v3+").contains(formatVersion);
     Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.avro.RandomAvroData;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -328,14 +329,39 @@ public class TestScansAndSchemaEvolution {
     // schema while the table itself uses the new one
     table.updateSchema().deleteColumn("data").commit();
 
-    List<FileScanTask> tasks =
-        Lists.newArrayList(
-            table
-                .newScan()
-                .useSnapshot(snapshotId)
-                .filter(Expressions.equal("data", "xyz"))
-                .planFiles());
-    assertThat(tasks).hasSize(2);
+    try (CloseableIterable<FileScanTask> tasks =
+        table
+            .newScan()
+            .useSnapshot(snapshotId)
+            .filter(Expressions.equal("data", "xyz"))
+            .planFiles()) {
+      assertThat(tasks).hasSize(2);
+    }
+  }
+
+  @TestTemplate
+  public void testBranchSnapshotWhenMainIsEmpty() throws IOException {
+    Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);
+
+    table
+        .newAppend()
+        .appendFile(createDataFile("one"))
+        .appendFile(createDataFile("two"))
+        .toBranch("branch")
+        .commit();
+    long snapshotId = table.snapshot("branch").snapshotId();
+    assertThat(table.currentSnapshot()).isNull();
+
+    table.updateSchema().deleteColumn("data").commit();
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table
+            .newScan()
+            .useSnapshot(snapshotId)
+            .filter(Expressions.equal("data", "xyz"))
+            .planFiles()) {
+      assertThat(tasks).hasSize(2);
+    }
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/actions/TestBaseRewriteDataFilesAction.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBaseRewriteDataFilesAction.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.List;
+import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.TestBase;
+import org.apache.iceberg.TestTables;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.FileIO;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestBaseRewriteDataFilesAction {
+  @TempDir private File tableDir;
+
+  @AfterEach
+  void cleanupTables() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  void currentSnapshotPinUsesCurrentSchema() throws Exception {
+    TestTables.TestTable table =
+        TestTables.create(tableDir, "test", TestBase.SCHEMA, TestBase.SPEC, 3);
+    table.newAppend().appendFile(TestBase.FILE_A).commit();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    RewriteDataFilesActionResult result =
+        new TestRewriteAction(table).filter(Expressions.notNull("renamed_data")).execute();
+
+    assertThat(result.deletedDataFiles()).isEmpty();
+    assertThat(result.addedDataFiles()).isEmpty();
+  }
+
+  private static class TestRewriteAction extends BaseRewriteDataFilesAction<TestRewriteAction> {
+    private TestRewriteAction(TestTables.TestTable table) {
+      super(table);
+    }
+
+    @Override
+    protected FileIO fileIO() {
+      return table().io();
+    }
+
+    @Override
+    protected List<DataFile> rewriteDataForTasks(List<CombinedScanTask> combinedScanTasks) {
+      throw new AssertionError("No rewrite should be necessary for a single file");
+    }
+
+    @Override
+    protected TestRewriteAction self() {
+      return this;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/actions/TestBinPackRewriteFilePlanner.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBinPackRewriteFilePlanner.java
@@ -136,6 +136,67 @@ class TestBinPackRewriteFilePlanner {
     assertThat(plan.totalGroupCount()).isZero();
   }
 
+  @Test
+  void currentSnapshotPinUsesCurrentSchema() {
+    addFiles();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    BinPackRewriteFilePlanner planner =
+        new BinPackRewriteFilePlanner(
+            table, Expressions.notNull("renamed_data"), snapshotId, false, false);
+    planner.init(REWRITE_ALL);
+
+    assertThat(planner.plan().totalGroupCount()).isEqualTo(3);
+  }
+
+  @Test
+  void branchSnapshotPinUsesCurrentSchemaWhenMainIsEmpty() {
+    table.newAppend().appendFile(FILE_1).appendFile(FILE_2).toBranch("branch").commit();
+    long snapshotId = table.snapshot("branch").snapshotId();
+    assertThat(table.currentSnapshot()).isNull();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    BinPackRewriteFilePlanner planner =
+        new BinPackRewriteFilePlanner(
+            table, Expressions.notNull("renamed_data"), snapshotId, false, false);
+    planner.init(REWRITE_ALL);
+
+    assertThat(planner.plan().totalGroupCount()).isOne();
+  }
+
+  @Test
+  void historicalBranchSnapshotUsesSnapshotSchemaWhenMainIsEmpty() {
+    table.newAppend().appendFile(FILE_1).appendFile(FILE_2).toBranch("branch").commit();
+    long historicalSnapshotId = table.snapshot("branch").snapshotId();
+    table.manageSnapshots().createBranch("historical-branch", historicalSnapshotId).commit();
+    table.newAppend().appendFile(FILE_4).appendFile(FILE_5).toBranch("branch").commit();
+    assertThat(table.currentSnapshot()).isNull();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    BinPackRewriteFilePlanner planner =
+        new BinPackRewriteFilePlanner(
+            table, Expressions.notNull("data"), historicalSnapshotId, false);
+    planner.init(REWRITE_ALL);
+
+    assertThat(planner.plan().totalGroupCount()).isOne();
+  }
+
+  @Test
+  void historicalSnapshotUsesSnapshotSchema() {
+    table.newAppend().appendFile(FILE_1).appendFile(FILE_2).commit();
+    long historicalSnapshotId = table.currentSnapshot().snapshotId();
+    table.newAppend().appendFile(FILE_4).appendFile(FILE_5).commit();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    BinPackRewriteFilePlanner planner =
+        new BinPackRewriteFilePlanner(
+            table, Expressions.notNull("data"), historicalSnapshotId, false);
+    planner.init(REWRITE_ALL);
+
+    assertThat(planner.plan().totalGroupCount()).isOne();
+  }
+
   @ParameterizedTest
   @EnumSource(
       value = RewriteJobOrder.class,

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DataTableScan;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
@@ -52,8 +53,13 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Scan;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.TableScanContext;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expressions;
@@ -159,8 +165,12 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
   }
 
   private void setParserContext(Table table) {
+    setParserContext(table.specs());
+  }
+
+  private void setParserContext(Map<Integer, PartitionSpec> specsById) {
     parserContext =
-        ParserContext.builder().add("specsById", table.specs()).add("caseSensitive", false).build();
+        ParserContext.builder().add("specsById", specsById).add("caseSensitive", false).build();
   }
 
   private void configurePlanningBehavior(
@@ -210,6 +220,52 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
     @Override
     public TestPlanningBehavior.Builder apply(TestPlanningBehavior.Builder builder) {
       return this.configurer.apply(builder);
+    }
+  }
+
+  private enum TaskDeliveryMode
+      implements Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> {
+    SYNCHRONOUS(TestPlanningBehavior.Builder::synchronous),
+    ASYNCHRONOUS(TestPlanningBehavior.Builder::asynchronous),
+    PAGINATED(TestPlanningBehavior.Builder::synchronousWithPagination);
+
+    private final Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> configurer;
+
+    TaskDeliveryMode(
+        Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> configurer) {
+      this.configurer = configurer;
+    }
+
+    @Override
+    public TestPlanningBehavior.Builder apply(TestPlanningBehavior.Builder builder) {
+      return this.configurer.apply(builder);
+    }
+  }
+
+  private static class IgnoringScanTable extends BaseTable {
+    private IgnoringScanTable(BaseTable table) {
+      super(table.operations(), table.name(), table.reporter());
+    }
+
+    @Override
+    public TableScan newScan() {
+      return new IgnoringDataTableScan(this, schema(), TableScanContext.empty());
+    }
+  }
+
+  private static class IgnoringDataTableScan extends DataTableScan {
+    private IgnoringDataTableScan(Table table, Schema schema, TableScanContext context) {
+      super(table, schema, context);
+    }
+
+    @Override
+    public TableScan option(String property, String value) {
+      return this;
+    }
+
+    @Override
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new IgnoringDataTableScan(table, schema, context);
     }
   }
 
@@ -685,6 +741,20 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
 
   @ParameterizedTest
   @EnumSource(PlanningMode.class)
+  void scanPlanningWithZeroMinRowsRequested(
+      Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> planMode)
+      throws IOException {
+    configurePlanningBehavior(planMode);
+    Table table = restTableFor(restCatalog, "zero_min_rows_requested_table");
+    setParserContext(table);
+
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().minRowsRequested(0L).planFiles()) {
+      assertThat(tasks).isEmpty();
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(PlanningMode.class)
   void remoteScanPlanningDeletesCancellation(
       Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> planMode)
       throws IOException {
@@ -864,6 +934,262 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
         .map(req -> (PlanTableScanRequest) req.body())
         .reduce((first, second) -> second)
         .orElseThrow(() -> new AssertionError("No PlanTableScanRequest captured"));
+  }
+
+  @Test
+  void exactSnapshotTimeTravelUsesSnapshotSchemaEndToEnd() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Table table = restTableFor(restCatalog, "exact_snapshot_time_travel_end_to_end");
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+    setParserContext(table);
+
+    TableScan scan = table.newScan().useSnapshot(snapshotId).filter(Expressions.notNull("data"));
+
+    assertThat(scan.schema().findField("data")).isNotNull();
+    assertThat(scan.schema().findField("renamed_data")).isNull();
+    assertThat(scan.snapshot().snapshotId()).isEqualTo(snapshotId);
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      assertThat(tasks).hasSize(1);
+      assertThat(captureLastPlanRequest().useSnapshotSchema()).isTrue();
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(TaskDeliveryMode.class)
+  void exactSnapshotTimeTravelReturnsSnapshotBoundSpecs(TaskDeliveryMode deliveryMode)
+      throws IOException {
+    configurePlanningBehavior(deliveryMode);
+    TableIdentifier identifier =
+        TableIdentifier.of(NS, "snapshot_bound_specs_" + deliveryMode.name().toLowerCase());
+    restCatalog.createNamespace(identifier.namespace());
+    PartitionSpec identitySpec = PartitionSpec.builderFor(SCHEMA).identity("id").build();
+    Table table =
+        restCatalog.buildTable(identifier, SCHEMA).withPartitionSpec(identitySpec).create();
+    PartitionSpec tableSpec = table.spec();
+    DataFile firstFile =
+        DataFiles.builder(tableSpec)
+            .withPath("/path/to/identity-1.parquet")
+            .withPartitionPath("id=1")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    DataFile secondFile =
+        DataFiles.builder(tableSpec)
+            .withPath("/path/to/identity-2.parquet")
+            .withPartitionPath("id=2")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    table.newAppend().appendFile(firstFile).appendFile(secondFile).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().updateColumn("id", Types.LongType.get()).commit();
+
+    TableScan scan = table.newScan().useSnapshot(snapshotId);
+    PartitionSpec snapshotSpec = tableSpec.toUnbound().bind(scan.schema(), true);
+    setParserContext(ImmutableMap.of(snapshotSpec.specId(), snapshotSpec));
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      assertThat(tasks).hasSize(2);
+      assertThat(tasks)
+          .allSatisfy(
+              task -> {
+                assertThat(task.spec().schema()).isEqualTo(SCHEMA);
+                assertThat(task.spec().partitionType().fieldType("id"))
+                    .isEqualTo(Types.IntegerType.get());
+              });
+    }
+  }
+
+  @Test
+  void exactSnapshotPinUsesCurrentSchemaEndToEnd() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Table table = restTableFor(restCatalog, "exact_snapshot_pin_end_to_end");
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+    setParserContext(table);
+
+    TableScan scan =
+        table
+            .newScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false")
+            .useSnapshot(snapshotId)
+            .filter(Expressions.notNull("renamed_data"));
+
+    assertThat(scan.schema()).isEqualTo(table.schema());
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      assertThat(tasks).hasSize(1);
+      assertThat(captureLastPlanRequest().useSnapshotSchema()).isFalse();
+    }
+  }
+
+  @Test
+  void exactSnapshotPinPreservesCapturedSchemaAcrossServerRefresh() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Table table = restTableFor(restCatalog, "exact_snapshot_pin_across_refresh");
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+    setParserContext(table);
+
+    TableScan scan =
+        table
+            .newScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false")
+            .useSnapshot(snapshotId)
+            .filter(Expressions.notNull("renamed_data"));
+
+    table.updateSchema().renameColumn("renamed_data", "server_data").commit();
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      assertThat(tasks).hasSize(1);
+      assertThat(tasks)
+          .allSatisfy(
+              task -> {
+                assertThat(task.spec().schema().findField("renamed_data")).isNotNull();
+                assertThat(task.spec().schema().findField("server_data")).isNull();
+              });
+      Schema requestedSchema = captureLastPlanRequest().scanSchema();
+      assertThat(requestedSchema.schemaId()).isEqualTo(scan.schema().schemaId());
+      assertThat(requestedSchema.sameSchema(scan.schema())).isTrue();
+    }
+  }
+
+  @Test
+  void rejectsRemovedAndReusedScanSchemaId() {
+    TableIdentifier identifier = TableIdentifier.of(NS, "reused_scan_schema_id");
+    backendCatalog.createNamespace(identifier.namespace());
+    BaseTable table =
+        (BaseTable) backendCatalog.buildTable(identifier, SCHEMA).withPartitionSpec(SPEC).create();
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    Schema initialSchema = table.schema();
+    table.updateSchema().renameColumn("data", "captured_data").commit();
+    Schema capturedSchema = table.schema();
+
+    TableOperations operations = table.operations();
+    TableMetadata current = operations.current();
+    operations.commit(
+        current,
+        TableMetadata.buildFrom(current).setCurrentSchema(initialSchema.schemaId()).build());
+    table.refresh();
+    table.expireSnapshots().cleanExpiredMetadata(true).commit();
+    assertThat(table.schemas()).doesNotContainKey(capturedSchema.schemaId());
+
+    table.updateSchema().renameColumn("data", "reused_data").commit();
+    assertThat(table.schema().schemaId()).isEqualTo(capturedSchema.schemaId());
+    assertThat(table.schema().sameSchema(capturedSchema)).isFalse();
+
+    PlanTableScanRequest request =
+        PlanTableScanRequest.builder()
+            .withSnapshotId(snapshotId)
+            .withUseSnapshotSchema(false)
+            .withScanSchema(capturedSchema)
+            .build();
+    assertThatThrownBy(
+            () ->
+                CatalogHandlers.planTableScan(
+                    backendCatalog, identifier, request, scan -> false, scan -> 100))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Scan schema with ID "
+                + capturedSchema.schemaId()
+                + " does not match the table schema with that ID");
+  }
+
+  @Test
+  void rejectsCustomScanThatIgnoresCapturedSchema() {
+    TableIdentifier identifier = TableIdentifier.of(NS, "ignored_scan_schema");
+    backendCatalog.createNamespace(identifier.namespace());
+    BaseTable table =
+        (BaseTable) backendCatalog.buildTable(identifier, SCHEMA).withPartitionSpec(SPEC).create();
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "captured_data").commit();
+    Schema capturedSchema = table.schema();
+    table.updateSchema().renameColumn("captured_data", "server_data").commit();
+
+    Catalog catalog = Mockito.mock(Catalog.class);
+    Mockito.when(catalog.loadTable(identifier)).thenReturn(new IgnoringScanTable(table));
+    PlanTableScanRequest request =
+        PlanTableScanRequest.builder()
+            .withSnapshotId(snapshotId)
+            .withUseSnapshotSchema(false)
+            .withScanSchema(capturedSchema)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                CatalogHandlers.planTableScan(
+                    catalog, identifier, request, scan -> false, scan -> 100))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("did not use requested scan schema with ID")
+        .hasMessageContaining(IgnoringDataTableScan.class.getName());
+  }
+
+  @Test
+  void rejectsCustomScanThatIgnoresCurrentSchemaSelection() {
+    TableIdentifier identifier = TableIdentifier.of(NS, "ignored_current_schema");
+    backendCatalog.createNamespace(identifier.namespace());
+    BaseTable table =
+        (BaseTable) backendCatalog.buildTable(identifier, SCHEMA).withPartitionSpec(SPEC).create();
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    Catalog catalog = Mockito.mock(Catalog.class);
+    Mockito.when(catalog.loadTable(identifier)).thenReturn(new IgnoringScanTable(table));
+    PlanTableScanRequest request =
+        PlanTableScanRequest.builder()
+            .withSnapshotId(snapshotId)
+            .withUseSnapshotSchema(false)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                CatalogHandlers.planTableScan(
+                    catalog, identifier, request, scan -> false, scan -> 100))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("did not use requested scan schema with ID")
+        .hasMessageContaining(IgnoringDataTableScan.class.getName());
+  }
+
+  @Test
+  void branchUsesCurrentSchemaAfterRenameEndToEnd() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Table table = restTableFor(restCatalog, "branch_current_schema_end_to_end");
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.manageSnapshots().createBranch("branch", snapshotId).commit();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+    setParserContext(table);
+
+    TableScan scan = table.newScan().useRef("branch").filter(Expressions.notNull("renamed_data"));
+
+    assertThat(scan.schema()).isEqualTo(table.schema());
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      assertThat(tasks).hasSize(1);
+      assertThat(captureLastPlanRequest().useSnapshotSchema()).isFalse();
+    }
+  }
+
+  @Test
+  void failedSnapshotRefinementDoesNotChangeBranchSchemaIntent() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Table table = restTableFor(restCatalog, "failed_snapshot_refinement");
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.manageSnapshots().createBranch("branch", snapshotId).commit();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+    setParserContext(table);
+
+    TableScan branchScan =
+        table.newScan().useRef("branch").filter(Expressions.notNull("renamed_data"));
+    assertThatThrownBy(() -> branchScan.useSnapshot(snapshotId))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot override snapshot, already set snapshot id=" + snapshotId);
+
+    try (CloseableIterable<FileScanTask> tasks = branchScan.planFiles()) {
+      assertThat(tasks).hasSize(1);
+      assertThat(captureLastPlanRequest().useSnapshotSchema()).isFalse();
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestPlanTableScanRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestPlanTableScanRequestParser.java
@@ -22,11 +22,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestPlanTableScanRequestParser {
+  private static final Schema SCAN_SCHEMA =
+      new Schema(7, Types.NestedField.required(1, "id", Types.IntegerType.get()));
 
   @Test
   public void nullAndEmptyCheck() {
@@ -79,6 +83,55 @@ public class TestPlanTableScanRequestParser {
     assertThatThrownBy(() -> PlanTableScanRequest.builder().withEndSnapshotId(5L).build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid incremental scan: startSnapshotId and endSnapshotId is required");
+  }
+
+  @Test
+  public void scanSchemaRequiresExactSnapshotWithCurrentSchemaSelection() {
+    assertThatThrownBy(() -> PlanTableScanRequest.builder().withScanSchema(SCAN_SCHEMA).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid scan: scanSchema requires snapshotId");
+
+    assertThatThrownBy(
+            () ->
+                PlanTableScanRequest.builder()
+                    .withSnapshotId(1L)
+                    .withUseSnapshotSchema(true)
+                    .withScanSchema(SCAN_SCHEMA)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid scan: scanSchema cannot be used when useSnapshotSchema is true");
+  }
+
+  @Test
+  public void scanSchemaRequiresSchemaId() {
+    assertThatThrownBy(
+            () ->
+                PlanTableScanRequestParser.fromJson(
+                    "{\"snapshot-id\":1,\"scan-schema\":{\"type\":\"struct\",\"fields\":[]}}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse scan-schema: missing required field schema-id");
+  }
+
+  @Test
+  public void roundTripSerdeWithScanSchemaAndDefaultFalse() {
+    String json =
+        "{\"snapshot-id\":1,"
+            + "\"case-sensitive\":true,"
+            + "\"scan-schema\":{\"type\":\"struct\",\"schema-id\":7,"
+            + "\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"int\"}]}}";
+
+    PlanTableScanRequest request = PlanTableScanRequestParser.fromJson(json);
+    assertThat(request.useSnapshotSchema()).isFalse();
+    assertThat(request.scanSchema().schemaId()).isEqualTo(SCAN_SCHEMA.schemaId());
+    assertThat(request.scanSchema().sameSchema(SCAN_SCHEMA)).isTrue();
+
+    String expectedJson =
+        "{\"snapshot-id\":1,"
+            + "\"case-sensitive\":true,"
+            + "\"use-snapshot-schema\":false,"
+            + "\"scan-schema\":{\"type\":\"struct\",\"schema-id\":7,"
+            + "\"fields\":[{\"id\":1,\"name\":\"id\",\"required\":true,\"type\":\"int\"}]}}";
+    assertThat(PlanTableScanRequestParser.toJson(request)).isEqualTo(expectedJson);
   }
 
   @Test

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
@@ -130,7 +130,8 @@ public class DataFileRewritePlanner
       }
 
       BinPackRewriteFilePlanner planner =
-          new BinPackRewriteFilePlanner(table, filterSupplier.get(), snapshot.snapshotId(), false);
+          new BinPackRewriteFilePlanner(
+              table, filterSupplier.get(), snapshot.snapshotId(), false, false);
       planner.init(rewriterOptions);
 
       FileRewritePlan<RewriteDataFiles.FileGroupInfo, FileScanTask, DataFile, RewriteFileGroup>

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotChanges;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.TableLoader;
@@ -627,7 +628,11 @@ public class EqualityConvertPlanner extends AbstractStreamOperator<ReadCommand>
     long commitSnapshotId = mainSnapshot.snapshotId();
 
     try (CloseableIterable<FileScanTask> tasks =
-        table.newScan().useSnapshot(commitSnapshotId).planFiles()) {
+        table
+            .newScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false")
+            .useSnapshot(commitSnapshotId)
+            .planFiles()) {
       for (FileScanTask task : tasks) {
         output.collect(
             new StreamRecord<>(

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.Scan;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
@@ -122,6 +123,10 @@ public class FlinkSplitPlanner {
       scan = refineScanWithBaseConfigs(scan, context, workerPool);
 
       if (context.snapshotId() != null) {
+        if (context.isStreaming()) {
+          scan = scan.option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false");
+        }
+
         scan = scan.useSnapshot(context.snapshotId());
       } else if (context.tag() != null) {
         scan = scan.useRef(context.tag());

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestDataFileRewritePlanner.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestDataFileRewritePlanner.java
@@ -247,6 +247,41 @@ class TestDataFileRewritePlanner extends OperatorTestBase {
   }
 
   @Test
+  void testBranchUsesCurrentSchemaAfterRename() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    String branchName = "schema-branch";
+    table.manageSnapshots().createBranch(branchName).commit();
+    insert(table, 3, "c");
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, DataFileRewritePlanner.PlannedGroup>
+        testHarness =
+            ProcessFunctionTestHarnesses.forProcessFunction(
+                new DataFileRewritePlanner(
+                    OperatorTestBase.DUMMY_TABLE_NAME,
+                    OperatorTestBase.DUMMY_TABLE_NAME,
+                    0,
+                    tableLoader(),
+                    11,
+                    10_000_000L,
+                    ImmutableMap.of(MIN_INPUT_FILES, "2"),
+                    () -> Expressions.notNull("renamed_data"),
+                    branchName))) {
+      testHarness.open();
+
+      trigger(testHarness);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+      List<DataFileRewritePlanner.PlannedGroup> planned = testHarness.extractOutputValues();
+      assertThat(planned).hasSize(1);
+      assertThat(planned.get(0).group().fileScanTasks()).hasSize(2);
+    }
+  }
+
+  @Test
   void testFilterSupplierWithTimestamp() throws Exception {
     Table table = createTableWithTimestampWithoutZone();
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -85,6 +86,32 @@ class TestEqualityConvertPlanner extends OperatorTestBase {
       assertThat(countEqDeleteTasks(commands)).isZero();
 
       assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void bootstrapUsesCurrentSchemaForPinnedTargetSnapshot() throws Exception {
+    Table table = createTableWithDelete(3);
+    table.updateSpec().addField("data").addField("id").commit();
+    insertFullPartitioned(table, 1, "a");
+    table.updateSchema().updateColumn("id", Types.LongType.get()).commit();
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<FileScanTask> tasks =
+          harness.extractOutputValues().stream()
+              .map(ReadCommand::task)
+              .filter(FileScanTask.class::isInstance)
+              .map(FileScanTask.class::cast)
+              .collect(Collectors.toList());
+      assertThat(tasks).hasSize(1);
+      assertThat(tasks.get(0).spec().partitionType().fieldType("id"))
+          .isEqualTo(Types.LongType.get());
     }
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.TestBase;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.TestTableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -115,6 +116,24 @@ public class TestStreamingMonitorFunction extends TestBase {
       TestHelpers.assertRecords(
           sourceContext.toRows(), Lists.newArrayList(Iterables.concat(recordsList)), SCHEMA);
     }
+  }
+
+  @TestTemplate
+  public void explicitSnapshotUsesSnapshotSchemaAfterRename() throws IOException {
+    writeRecords(RandomGenericData.generate(SCHEMA, 10, 0L));
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .useSnapshotId(snapshotId)
+            .project(SCHEMA)
+            .filters(ImmutableList.of(Expressions.notNull("data")))
+            .build();
+
+    FlinkInputSplit[] splits =
+        FlinkSplitPlanner.planInputSplits(table, scanContext, ThreadPools.getWorkerPool());
+    assertThat(splits).hasSize(1);
   }
 
   @TestTemplate

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -33,11 +33,13 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.HadoopTableExtension;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.junit.jupiter.api.BeforeEach;
@@ -173,6 +175,26 @@ public class TestContinuousSplitPlannerImpl {
     for (int i = 0; i < 3; ++i) {
       lastPosition = verifyOneCycle(splitPlanner, lastPosition).lastPosition;
     }
+  }
+
+  @Test
+  void initialTableScanUsesCurrentSchemaAfterRename() throws Exception {
+    appendTwoSnapshots();
+    TABLE_RESOURCE.table().updateSchema().renameColumn("data", "renamed_data").commit();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .project(TABLE_RESOURCE.table().schema())
+            .filters(ImmutableList.of(Expressions.notNull("renamed_data")))
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    ContinuousEnumerationResult result = splitPlanner.planSplits(null);
+    assertThat(result.splits()).hasSize(1);
+    assertThat(Iterables.getOnlyElement(result.splits()).task().files()).hasSize(2);
   }
 
   @ParameterizedTest

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
@@ -130,7 +130,8 @@ public class DataFileRewritePlanner
       }
 
       BinPackRewriteFilePlanner planner =
-          new BinPackRewriteFilePlanner(table, filterSupplier.get(), snapshot.snapshotId(), false);
+          new BinPackRewriteFilePlanner(
+              table, filterSupplier.get(), snapshot.snapshotId(), false, false);
       planner.init(rewriterOptions);
 
       FileRewritePlan<RewriteDataFiles.FileGroupInfo, FileScanTask, DataFile, RewriteFileGroup>

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotChanges;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.TableLoader;
@@ -627,7 +628,11 @@ public class EqualityConvertPlanner extends AbstractStreamOperator<ReadCommand>
     long commitSnapshotId = mainSnapshot.snapshotId();
 
     try (CloseableIterable<FileScanTask> tasks =
-        table.newScan().useSnapshot(commitSnapshotId).planFiles()) {
+        table
+            .newScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false")
+            .useSnapshot(commitSnapshotId)
+            .planFiles()) {
       for (FileScanTask task : tasks) {
         output.collect(
             new StreamRecord<>(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.Scan;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
@@ -122,6 +123,10 @@ public class FlinkSplitPlanner {
       scan = refineScanWithBaseConfigs(scan, context, workerPool);
 
       if (context.snapshotId() != null) {
+        if (context.isStreaming()) {
+          scan = scan.option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false");
+        }
+
         scan = scan.useSnapshot(context.snapshotId());
       } else if (context.tag() != null) {
         scan = scan.useRef(context.tag());

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestDataFileRewritePlanner.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestDataFileRewritePlanner.java
@@ -247,6 +247,41 @@ class TestDataFileRewritePlanner extends OperatorTestBase {
   }
 
   @Test
+  void testBranchUsesCurrentSchemaAfterRename() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    String branchName = "schema-branch";
+    table.manageSnapshots().createBranch(branchName).commit();
+    insert(table, 3, "c");
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, DataFileRewritePlanner.PlannedGroup>
+        testHarness =
+            ProcessFunctionTestHarnesses.forProcessFunction(
+                new DataFileRewritePlanner(
+                    OperatorTestBase.DUMMY_TABLE_NAME,
+                    OperatorTestBase.DUMMY_TABLE_NAME,
+                    0,
+                    tableLoader(),
+                    11,
+                    10_000_000L,
+                    ImmutableMap.of(MIN_INPUT_FILES, "2"),
+                    () -> Expressions.notNull("renamed_data"),
+                    branchName))) {
+      testHarness.open();
+
+      trigger(testHarness);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+      List<DataFileRewritePlanner.PlannedGroup> planned = testHarness.extractOutputValues();
+      assertThat(planned).hasSize(1);
+      assertThat(planned.get(0).group().fileScanTasks()).hasSize(2);
+    }
+  }
+
+  @Test
   void testFilterSupplierWithTimestamp() throws Exception {
     Table table = createTableWithTimestampWithoutZone();
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -85,6 +86,32 @@ class TestEqualityConvertPlanner extends OperatorTestBase {
       assertThat(countEqDeleteTasks(commands)).isZero();
 
       assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void bootstrapUsesCurrentSchemaForPinnedTargetSnapshot() throws Exception {
+    Table table = createTableWithDelete(3);
+    table.updateSpec().addField("data").addField("id").commit();
+    insertFullPartitioned(table, 1, "a");
+    table.updateSchema().updateColumn("id", Types.LongType.get()).commit();
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<FileScanTask> tasks =
+          harness.extractOutputValues().stream()
+              .map(ReadCommand::task)
+              .filter(FileScanTask.class::isInstance)
+              .map(FileScanTask.class::cast)
+              .collect(Collectors.toList());
+      assertThat(tasks).hasSize(1);
+      assertThat(tasks.get(0).spec().partitionType().fieldType("id"))
+          .isEqualTo(Types.LongType.get());
     }
   }
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.TestBase;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.TestTableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -115,6 +116,24 @@ public class TestStreamingMonitorFunction extends TestBase {
       TestHelpers.assertRecords(
           sourceContext.toRows(), Lists.newArrayList(Iterables.concat(recordsList)), SCHEMA);
     }
+  }
+
+  @TestTemplate
+  public void explicitSnapshotUsesSnapshotSchemaAfterRename() throws IOException {
+    writeRecords(RandomGenericData.generate(SCHEMA, 10, 0L));
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .useSnapshotId(snapshotId)
+            .project(SCHEMA)
+            .filters(ImmutableList.of(Expressions.notNull("data")))
+            .build();
+
+    FlinkInputSplit[] splits =
+        FlinkSplitPlanner.planInputSplits(table, scanContext, ThreadPools.getWorkerPool());
+    assertThat(splits).hasSize(1);
   }
 
   @TestTemplate

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -33,11 +33,13 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.HadoopTableExtension;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.junit.jupiter.api.BeforeEach;
@@ -173,6 +175,26 @@ public class TestContinuousSplitPlannerImpl {
     for (int i = 0; i < 3; ++i) {
       lastPosition = verifyOneCycle(splitPlanner, lastPosition).lastPosition;
     }
+  }
+
+  @Test
+  void initialTableScanUsesCurrentSchemaAfterRename() throws Exception {
+    appendTwoSnapshots();
+    TABLE_RESOURCE.table().updateSchema().renameColumn("data", "renamed_data").commit();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .project(TABLE_RESOURCE.table().schema())
+            .filters(ImmutableList.of(Expressions.notNull("renamed_data")))
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    ContinuousEnumerationResult result = splitPlanner.planSplits(null);
+    assertThat(result.splits()).hasSize(1);
+    assertThat(Iterables.getOnlyElement(result.splits()).task().files()).hasSize(2);
   }
 
   @ParameterizedTest

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
@@ -130,7 +130,8 @@ public class DataFileRewritePlanner
       }
 
       BinPackRewriteFilePlanner planner =
-          new BinPackRewriteFilePlanner(table, filterSupplier.get(), snapshot.snapshotId(), false);
+          new BinPackRewriteFilePlanner(
+              table, filterSupplier.get(), snapshot.snapshotId(), false, false);
       planner.init(rewriterOptions);
 
       FileRewritePlan<RewriteDataFiles.FileGroupInfo, FileScanTask, DataFile, RewriteFileGroup>

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotChanges;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.TableLoader;
@@ -627,7 +628,11 @@ public class EqualityConvertPlanner extends AbstractStreamOperator<ReadCommand>
     long commitSnapshotId = mainSnapshot.snapshotId();
 
     try (CloseableIterable<FileScanTask> tasks =
-        table.newScan().useSnapshot(commitSnapshotId).planFiles()) {
+        table
+            .newScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false")
+            .useSnapshot(commitSnapshotId)
+            .planFiles()) {
       for (FileScanTask task : tasks) {
         output.collect(
             new StreamRecord<>(

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.Scan;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
@@ -122,6 +123,10 @@ public class FlinkSplitPlanner {
       scan = refineScanWithBaseConfigs(scan, context, workerPool);
 
       if (context.snapshotId() != null) {
+        if (context.isStreaming()) {
+          scan = scan.option(SnapshotScan.USE_SNAPSHOT_SCHEMA, "false");
+        }
+
         scan = scan.useSnapshot(context.snapshotId());
       } else if (context.tag() != null) {
         scan = scan.useRef(context.tag());

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestDataFileRewritePlanner.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestDataFileRewritePlanner.java
@@ -247,6 +247,41 @@ class TestDataFileRewritePlanner extends OperatorTestBase {
   }
 
   @Test
+  void testBranchUsesCurrentSchemaAfterRename() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    String branchName = "schema-branch";
+    table.manageSnapshots().createBranch(branchName).commit();
+    insert(table, 3, "c");
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, DataFileRewritePlanner.PlannedGroup>
+        testHarness =
+            ProcessFunctionTestHarnesses.forProcessFunction(
+                new DataFileRewritePlanner(
+                    OperatorTestBase.DUMMY_TABLE_NAME,
+                    OperatorTestBase.DUMMY_TABLE_NAME,
+                    0,
+                    tableLoader(),
+                    11,
+                    10_000_000L,
+                    ImmutableMap.of(MIN_INPUT_FILES, "2"),
+                    () -> Expressions.notNull("renamed_data"),
+                    branchName))) {
+      testHarness.open();
+
+      trigger(testHarness);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+      List<DataFileRewritePlanner.PlannedGroup> planned = testHarness.extractOutputValues();
+      assertThat(planned).hasSize(1);
+      assertThat(planned.get(0).group().fileScanTasks()).hasSize(2);
+    }
+  }
+
+  @Test
   void testFilterSupplierWithTimestamp() throws Exception {
     Table table = createTableWithTimestampWithoutZone();
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -85,6 +86,32 @@ class TestEqualityConvertPlanner extends OperatorTestBase {
       assertThat(countEqDeleteTasks(commands)).isZero();
 
       assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void bootstrapUsesCurrentSchemaForPinnedTargetSnapshot() throws Exception {
+    Table table = createTableWithDelete(3);
+    table.updateSpec().addField("data").addField("id").commit();
+    insertFullPartitioned(table, 1, "a");
+    table.updateSchema().updateColumn("id", Types.LongType.get()).commit();
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<FileScanTask> tasks =
+          harness.extractOutputValues().stream()
+              .map(ReadCommand::task)
+              .filter(FileScanTask.class::isInstance)
+              .map(FileScanTask.class::cast)
+              .collect(Collectors.toList());
+      assertThat(tasks).hasSize(1);
+      assertThat(tasks.get(0).spec().partitionType().fieldType("id"))
+          .isEqualTo(Types.LongType.get());
     }
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestStreamingMonitorFunction.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.TestBase;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.TestTableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -115,6 +116,24 @@ public class TestStreamingMonitorFunction extends TestBase {
       TestHelpers.assertRecords(
           sourceContext.toRows(), Lists.newArrayList(Iterables.concat(recordsList)), SCHEMA);
     }
+  }
+
+  @TestTemplate
+  public void explicitSnapshotUsesSnapshotSchemaAfterRename() throws IOException {
+    writeRecords(RandomGenericData.generate(SCHEMA, 10, 0L));
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().renameColumn("data", "renamed_data").commit();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .useSnapshotId(snapshotId)
+            .project(SCHEMA)
+            .filters(ImmutableList.of(Expressions.notNull("data")))
+            .build();
+
+    FlinkInputSplit[] splits =
+        FlinkSplitPlanner.planInputSplits(table, scanContext, ThreadPools.getWorkerPool());
+    assertThat(splits).hasSize(1);
   }
 
   @TestTemplate

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -33,11 +33,13 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.HadoopTableExtension;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.junit.jupiter.api.BeforeEach;
@@ -173,6 +175,26 @@ public class TestContinuousSplitPlannerImpl {
     for (int i = 0; i < 3; ++i) {
       lastPosition = verifyOneCycle(splitPlanner, lastPosition).lastPosition;
     }
+  }
+
+  @Test
+  void initialTableScanUsesCurrentSchemaAfterRename() throws Exception {
+    appendTwoSnapshots();
+    TABLE_RESOURCE.table().updateSchema().renameColumn("data", "renamed_data").commit();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .project(TABLE_RESOURCE.table().schema())
+            .filters(ImmutableList.of(Expressions.notNull("renamed_data")))
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    ContinuousEnumerationResult result = splitPlanner.planSplits(null);
+    assertThat(result.splits()).hasSize(1);
+    assertThat(Iterables.getOnlyElement(result.splits()).task().files()).hasSize(2);
   }
 
   @ParameterizedTest

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -2057,6 +2057,11 @@ class PlanTableScanRequest(BaseModel):
         alias='use-snapshot-schema',
         description='Whether to use the schema at the time the snapshot was written.\nWhen time travelling, the snapshot schema should be used (true). When scanning a branch, the table schema should be used (false).',
     )
+    scan_schema: ScanSchema | None = Field(
+        None,
+        alias='scan-schema',
+        description='The table schema captured by the client when use-snapshot-schema is false.\nClients SHOULD supply this schema to keep planning stable across concurrent table schema updates. If supplied, snapshot-id MUST be set and use-snapshot-schema MUST be false. Servers MUST validate both its schema ID and content against table metadata.',
+    )
     start_snapshot_id: int | None = Field(
         None,
         alias='start-snapshot-id',
@@ -2090,6 +2095,11 @@ class FileScanTask(BaseModel):
 
 class Schema(StructType):
     schema_id: int | None = Field(None, alias='schema-id')
+    identifier_field_ids: list[int] | None = Field(None, alias='identifier-field-ids')
+
+
+class ScanSchema(StructType):
+    schema_id: int = Field(..., alias='schema-id')
     identifier_field_ids: list[int] | None = Field(None, alias='identifier-field-ids')
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2534,6 +2534,20 @@ components:
               items:
                 type: integer
 
+    ScanSchema:
+      allOf:
+        - $ref: '#/components/schemas/StructType'
+        - type: object
+          required:
+            - schema-id
+          properties:
+            schema-id:
+              type: integer
+            identifier-field-ids:
+              type: array
+              items:
+                type: integer
+
     Predicate:
       oneOf:
         - type: boolean
@@ -5342,6 +5356,15 @@ components:
             When scanning a branch, the table schema should be used (false).
           type: boolean
           default: false
+        scan-schema:
+          description:
+            The table schema captured by the client when use-snapshot-schema is false.
+
+            Clients SHOULD supply this schema to keep planning stable across concurrent
+            table schema updates. If supplied, snapshot-id MUST be set and
+            use-snapshot-schema MUST be false. Servers MUST validate both its schema ID
+            and content against table metadata.
+          $ref: '#/components/schemas/ScanSchema'
         start-snapshot-id:
           description: Starting snapshot ID for an incremental scan (exclusive)
           type: integer

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -139,6 +139,29 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
   }
 
   @TestTemplate
+  public void testDeleteAfterSchemaOnlyRename() throws NoSuchTableException {
+    createAndInitUnpartitionedTable();
+    append(tableName, new Employee(1, "hr"), new Employee(2, "hardware"));
+    createBranchIfNeeded();
+
+    sql("ALTER TABLE %s RENAME COLUMN id TO employee_id", tableName);
+    sql("DELETE FROM %s WHERE employee_id = 1", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    if (mode(table) == COPY_ON_WRITE) {
+      validateCopyOnWrite(currentSnapshot, "1", "1", "1");
+    } else {
+      validateMergeOnRead(currentSnapshot, "1", "1", null);
+    }
+
+    assertEquals(
+        "Should delete using the renamed column",
+        ImmutableList.of(row(2, "hardware")),
+        sql("SELECT * FROM %s ORDER BY employee_id", selectTarget()));
+  }
+
+  @TestTemplate
   public void testCoalesceDelete() throws Exception {
     createAndInitUnpartitionedTable();
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -1232,6 +1232,36 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteDataFilesOnDivergedBranchAfterSchemaOnlyRename() {
+    createTable();
+    insertData(10);
+
+    String branchName = "schemaBranch";
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName);
+    insertData(tableName, 10);
+    sql("ALTER TABLE %s RENAME COLUMN c1 TO renamed_c1", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    long mainSnapshotId = table.currentSnapshot().snapshotId();
+    long branchSnapshotId = table.refs().get(branchName).snapshotId();
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_data_files("
+                + "table => '%s', branch => '%s', where => 'renamed_c1 > 0')",
+            catalogName, tableName, branchName);
+
+    assertEquals(
+        "Action should rewrite branch files using the renamed column",
+        row(10, 1),
+        Arrays.copyOf(output.get(0), 2));
+
+    table.refresh();
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotId);
+    assertThat(table.refs().get(branchName).snapshotId()).isNotEqualTo(branchSnapshotId);
+  }
+
+  @TestTemplate
   public void testBranchCompactionDoesNotAffectMain() {
     createTable();
     // create 10 files under non-partitioned table

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -207,8 +207,10 @@ public class RewriteDataFilesSparkAction
   private void init(long startingSnapshotId) {
     this.planner =
         runner instanceof SparkShufflingFileRewriteRunner
-            ? new SparkShufflingDataRewritePlanner(table, filter, startingSnapshotId, caseSensitive)
-            : new BinPackRewriteFilePlanner(table, filter, startingSnapshotId, caseSensitive);
+            ? new SparkShufflingDataRewritePlanner(
+                table, filter, startingSnapshotId, caseSensitive, false)
+            : new BinPackRewriteFilePlanner(
+                table, filter, startingSnapshotId, caseSensitive, false);
 
     // Default to BinPack if no strategy selected
     if (this.runner == null) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewritePlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewritePlanner.java
@@ -50,7 +50,16 @@ class SparkShufflingDataRewritePlanner extends BinPackRewriteFilePlanner {
 
   SparkShufflingDataRewritePlanner(
       Table table, Expression filter, Long snapshotId, boolean caseSensitive) {
-    super(table, filter, snapshotId, caseSensitive);
+    this(table, filter, snapshotId, caseSensitive, true);
+  }
+
+  SparkShufflingDataRewritePlanner(
+      Table table,
+      Expression filter,
+      Long snapshotId,
+      boolean caseSensitive,
+      boolean useSnapshotSchema) {
+    super(table, filter, snapshotId, caseSensitive, useSnapshotSchema);
   }
 
   @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.MetricsModes;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.SparkDistributedDataScan;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -665,6 +666,7 @@ public class SparkScanBuilder
 
     BatchScan scan =
         newBatchScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString())
             .useSnapshot(snapshotId)
             .caseSensitive(caseSensitive)
             .filter(filterExpression())
@@ -701,6 +703,7 @@ public class SparkScanBuilder
     BatchScan scan =
         table
             .newBatchScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString())
             .useSnapshot(snapshot.snapshotId())
             .ignoreResiduals()
             .caseSensitive(caseSensitive)

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -139,6 +139,29 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
   }
 
   @TestTemplate
+  public void testDeleteAfterSchemaOnlyRename() throws NoSuchTableException {
+    createAndInitUnpartitionedTable();
+    append(tableName, new Employee(1, "hr"), new Employee(2, "hardware"));
+    createBranchIfNeeded();
+
+    sql("ALTER TABLE %s RENAME COLUMN id TO employee_id", tableName);
+    sql("DELETE FROM %s WHERE employee_id = 1", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot currentSnapshot = SnapshotUtil.latestSnapshot(table, branch);
+    if (mode(table) == COPY_ON_WRITE) {
+      validateCopyOnWrite(currentSnapshot, "1", "1", "1");
+    } else {
+      validateMergeOnRead(currentSnapshot, "1", "1", null);
+    }
+
+    assertEquals(
+        "Should delete using the renamed column",
+        ImmutableList.of(row(2, "hardware")),
+        sql("SELECT * FROM %s ORDER BY employee_id", selectTarget()));
+  }
+
+  @TestTemplate
   public void testCoalesceDelete() throws Exception {
     createAndInitUnpartitionedTable();
 

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -1230,6 +1230,36 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteDataFilesOnDivergedBranchAfterSchemaOnlyRename() {
+    createTable();
+    insertData(10);
+
+    String branchName = "schemaBranch";
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName);
+    insertData(tableName, 10);
+    sql("ALTER TABLE %s RENAME COLUMN c1 TO renamed_c1", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    long mainSnapshotId = table.currentSnapshot().snapshotId();
+    long branchSnapshotId = table.refs().get(branchName).snapshotId();
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_data_files("
+                + "table => '%s', branch => '%s', where => 'renamed_c1 > 0')",
+            catalogName, tableName, branchName);
+
+    assertEquals(
+        "Action should rewrite branch files using the renamed column",
+        row(10, 1),
+        Arrays.copyOf(output.get(0), 2));
+
+    table.refresh();
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotId);
+    assertThat(table.refs().get(branchName).snapshotId()).isNotEqualTo(branchSnapshotId);
+  }
+
+  @TestTemplate
   public void testBranchCompactionDoesNotAffectMain() {
     createTable();
     // create 10 files under non-partitioned table

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -207,8 +207,10 @@ public class RewriteDataFilesSparkAction
   private void init(long startingSnapshotId) {
     this.planner =
         runner instanceof SparkShufflingFileRewriteRunner
-            ? new SparkShufflingDataRewritePlanner(table, filter, startingSnapshotId, caseSensitive)
-            : new BinPackRewriteFilePlanner(table, filter, startingSnapshotId, caseSensitive);
+            ? new SparkShufflingDataRewritePlanner(
+                table, filter, startingSnapshotId, caseSensitive, false)
+            : new BinPackRewriteFilePlanner(
+                table, filter, startingSnapshotId, caseSensitive, false);
 
     // Default to BinPack if no strategy selected
     if (this.runner == null) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewritePlanner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewritePlanner.java
@@ -50,7 +50,16 @@ class SparkShufflingDataRewritePlanner extends BinPackRewriteFilePlanner {
 
   SparkShufflingDataRewritePlanner(
       Table table, Expression filter, Long snapshotId, boolean caseSensitive) {
-    super(table, filter, snapshotId, caseSensitive);
+    this(table, filter, snapshotId, caseSensitive, true);
+  }
+
+  SparkShufflingDataRewritePlanner(
+      Table table,
+      Expression filter,
+      Long snapshotId,
+      boolean caseSensitive,
+      boolean useSnapshotSchema) {
+    super(table, filter, snapshotId, caseSensitive, useSnapshotSchema);
   }
 
   @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.MetricsModes;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.SparkDistributedDataScan;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -677,6 +678,7 @@ public class SparkScanBuilder
 
     BatchScan scan =
         newBatchScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString())
             .useSnapshot(snapshotId)
             .caseSensitive(caseSensitive)
             .filter(filterExpression())
@@ -713,6 +715,7 @@ public class SparkScanBuilder
     BatchScan scan =
         table
             .newBatchScan()
+            .option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString())
             .useSnapshot(snapshot.snapshotId())
             .ignoreResiduals()
             .caseSensitive(caseSensitive)

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -319,6 +319,25 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
   }
 
   @TestTemplate
+  public void testMetadataDeleteAfterSchemaOnlyRename() throws NoSuchTableException {
+    assumeThat(branch).as("Test only applies to the main branch").isNull();
+    createAndInitPartitionedTable();
+    append(tableName, new Employee(1, "hr"));
+    append(tableName, new Employee(2, "hardware"));
+
+    sql("ALTER TABLE %s RENAME COLUMN id TO employee_id", tableName);
+    sql("DELETE FROM %s WHERE employee_id = 1", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    validateDelete(table.currentSnapshot(), "1", "1");
+
+    assertEquals(
+        "Should delete using the renamed column",
+        ImmutableList.of(row(2, "hardware")),
+        sql("SELECT * FROM %s ORDER BY employee_id", tableName));
+  }
+
+  @TestTemplate
   public void testDeleteFileThenMetadataDelete() throws Exception {
     assumeThat(fileFormat)
         .as("Avro does not support metadata delete")

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteDataFilesProcedure.java
@@ -1239,6 +1239,36 @@ public class TestRewriteDataFilesProcedure extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void testRewriteDataFilesOnDivergedBranchAfterSchemaOnlyRename() {
+    createTable();
+    insertData(10);
+
+    String branchName = "schemaBranch";
+    sql("ALTER TABLE %s CREATE BRANCH %s", tableName, branchName);
+    insertData(tableName, 10);
+    sql("ALTER TABLE %s RENAME COLUMN c1 TO renamed_c1", tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    long mainSnapshotId = table.currentSnapshot().snapshotId();
+    long branchSnapshotId = table.refs().get(branchName).snapshotId();
+
+    List<Object[]> output =
+        sql(
+            "CALL %s.system.rewrite_data_files("
+                + "table => '%s', branch => '%s', where => 'renamed_c1 > 0')",
+            catalogName, tableName, branchName);
+
+    assertEquals(
+        "Action should rewrite branch files using the renamed column",
+        row(10, 1),
+        Arrays.copyOf(output.get(0), 2));
+
+    table.refresh();
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotId);
+    assertThat(table.refs().get(branchName).snapshotId()).isNotEqualTo(branchSnapshotId);
+  }
+
+  @TestTemplate
   public void testBranchCompactionDoesNotAffectMain() {
     createTable();
     // create 10 files under non-partitioned table

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -207,8 +207,10 @@ public class RewriteDataFilesSparkAction
   private void init(long startingSnapshotId) {
     this.planner =
         runner instanceof SparkShufflingFileRewriteRunner
-            ? new SparkShufflingDataRewritePlanner(table, filter, startingSnapshotId, caseSensitive)
-            : new BinPackRewriteFilePlanner(table, filter, startingSnapshotId, caseSensitive);
+            ? new SparkShufflingDataRewritePlanner(
+                table, filter, startingSnapshotId, caseSensitive, false)
+            : new BinPackRewriteFilePlanner(
+                table, filter, startingSnapshotId, caseSensitive, false);
 
     // Default to BinPack if no strategy selected
     if (this.runner == null) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewritePlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SparkShufflingDataRewritePlanner.java
@@ -50,7 +50,16 @@ class SparkShufflingDataRewritePlanner extends BinPackRewriteFilePlanner {
 
   SparkShufflingDataRewritePlanner(
       Table table, Expression filter, Long snapshotId, boolean caseSensitive) {
-    super(table, filter, snapshotId, caseSensitive);
+    this(table, filter, snapshotId, caseSensitive, true);
+  }
+
+  SparkShufflingDataRewritePlanner(
+      Table table,
+      Expression filter,
+      Long snapshotId,
+      boolean caseSensitive,
+      boolean useSnapshotSchema) {
+    super(table, filter, snapshotId, caseSensitive, useSnapshotSchema);
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.MetricsModes;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.SparkDistributedDataScan;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
@@ -349,8 +350,12 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
             .project(projection)
             .metricsReporter(metricsReporter());
 
-    if (shouldPinSnapshot() || timeTravel != null) {
+    if (timeTravel != null) {
       scan = scan.useSnapshot(snapshot.snapshotId());
+    } else if (shouldPinSnapshot()) {
+      scan =
+          scan.option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString())
+              .useSnapshot(snapshot.snapshotId());
     }
 
     Preconditions.checkState(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SnapshotScan;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.exceptions.ValidationException;
@@ -234,7 +235,9 @@ public class SparkTable extends BaseSparkTable
     if (scanBranch != null) {
       scan = scan.useRef(scanBranch);
     } else if (snapshot != null) {
-      scan = scan.useSnapshot(snapshot.snapshotId());
+      scan =
+          scan.option(SnapshotScan.USE_SNAPSHOT_SCHEMA, Boolean.FALSE.toString())
+              .useSnapshot(snapshot.snapshotId());
     }
 
     try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {


### PR DESCRIPTION
Follow-up to apache/iceberg#13301 and apache/iceberg#14438.

## Problem

`SnapshotScan#specs` skips rebinding partition specs when the requested snapshot is the table's current snapshot or when `main` has no current snapshot. Neither condition proves that the specs and scan use the same schema:

- Schema evolution does not create a snapshot. After a column is dropped or renamed, an explicit `useSnapshot(id)` scan can target the current snapshot while correctly using that snapshot's older schema.
- Iceberg can have an empty `main` branch while another branch has a snapshot. This is already exercised by `TestFastAppend.testAppendToBranchEmptyTable`, and this PR adds a direct scan regression.

In both cases, leaving specs bound to the table's newer schema can fail filter binding, for example:

```
Cannot find field 'data' in struct: struct<1: id: required long, 3: part: required string>
```

The fix skips spec rebinding only when the specs are actually bound to the scan's schema.

## Snapshot semantics and compatibility

Iceberg has two distinct uses of an exact snapshot ID:

1. Explicit time travel expects the snapshot's schema. This remains the default.
2. Internal operations sometimes capture an exact ID only to keep planning consistent while intentionally using the operation's current or selected-branch schema.

Correcting spec rebinding exposes the second group after schema-only evolution. This PR adds the exact-snapshot option `use-snapshot-schema` (default `true`). Consistency-pin callers set it to `false` before `useSnapshot(id)`; explicit time travel does not set it.

Focused negative controls demonstrated that the compatibility annotations are required in:

- Core and bin-pack rewrite planning
- Flink streaming and maintenance planning in 1.20, 2.0, and 2.1
- Spark row-level and rewrite planning in 3.5, 4.0, and 4.1
- Spark 4.1 exact-pin metadata deletes
- REST scan planning

Rewrite callers pass their schema intent explicitly. They no longer infer it from whether the snapshot happens to be `main` or another branch head, so a historical snapshot retains snapshot-schema semantics even when it remains the head of a different branch.

External integrations that use `useSnapshot(id)` as a current-schema consistency pin should set `use-snapshot-schema=false` before `useSnapshot`. Explicit time-travel callers should keep the default.

## Why REST changes are required here

REST scan planning moves a `TableScan` refinement across a client/server boundary. Merely forwarding `use-snapshot-schema=false` is insufficient: the server may refresh after the client captures its schema, and task partition specs must be bound to the same effective schema as the scan.

This PR therefore keeps the existing REST behavior consistent with the Core fix:

- The client sends its optional captured `scan-schema` for an exact current-schema pin.
- The server validates the schema ID and content against table metadata and verifies that custom scans honored the requested schema.
- Legacy requests without `scan-schema` retain the schema captured by the server before `useSnapshot`.
- Responses serialize specs bound to the planned tasks for synchronous, asynchronous, and paginated delivery.
- The client parses tasks with the effective scan specs.
- Zero-row asynchronous planning returns an explicit empty task state.
- `RESTTableScan` refinements keep schema intent on the returned scan rather than mutating the source scan.
- Serialized `scan-schema` is removed from scan-report metadata to avoid reporting a potentially large schema as an option value.

These are compatibility requirements caused by the Core correction, not a general REST planning redesign.

## Compatibility notes and follow-ups

- Older REST clients cannot send `scan-schema`; for those requests, the server can only use the table schema it sees when handling the request. Upgraded clients preserve the schema captured before a concurrent server refresh.
- Custom `TableScan` implementations used by REST servers must honor the exact-snapshot schema option. The reference handler now rejects a scan that ignores it instead of returning a silently inconsistent plan.
- REST planning implementations outside `CatalogHandlers` should follow the optional `scan-schema` and task-bound-spec behavior documented in the OpenAPI schema.

## Validation

- Full `:iceberg-core:test` suite
- Full focused Core, REST, request-parser, and OpenAPI suites
- Flink 1.20, 2.0, and 2.1 streaming, maintenance, explicit-snapshot, and selected-branch regressions
- Flink 2.1 rewrite-action suite
- Spark 3.5 and 4.0 COW/MOR rename regressions
- Spark 3.5, 4.0, and 4.1 selected-branch rewrite regressions
- Spark 4.1 metadata-delete, distributed Java/Kryo, time-travel, and branch coverage
- The two Spark 4.1 tests that failed on the previous PR head:
  - `TestFilterPushDown.testFilterPushdownOnNestedInitialDefaultColumnAbsentFromFile`
  - `TestRuntimeFiltering.testRenamedSourceColumnTable`
- `make generate`
- `make lint`
- OpenAPI validation
- `spotlessCheck` with all changed Spark and Flink versions enabled
- `revapi`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Investigate and fix snapshot-schema/spec mismatches after schema-only evolution, preserve proven consistency-pin callers, add regressions, and document compatibility boundaries.
