### PR TITLE
Core: Preserve scan schemas in REST planning

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -49,6 +49,8 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
+import org.apache.iceberg.DataTableScan;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
 import org.apache.iceberg.MetadataUpdate.UpgradeFormatVersion;
@@ -56,11 +58,13 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RetryableValidationException;
 import org.apache.iceberg.Scan;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.TableScanContext;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.Catalog;
@@ -76,6 +80,7 @@ import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -102,6 +107,7 @@ import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.SQLViewRepresentation;
@@ -842,7 +848,8 @@ public class CatalogHandlers {
       TableScan tableScan = table.newScan();
 
       if (request.snapshotId() != null) {
-        tableScan = tableScan.useSnapshot(request.snapshotId());
+        long snapshotId = request.snapshotId();
+        tableScan = scanSnapshot(table, tableScan, snapshotId, request.useSnapshotSchema());
       }
 
       // Apply filters and projections using common method
@@ -881,7 +888,7 @@ public class CatalogHandlers {
             .withPlanStatus(PlanStatus.COMPLETED)
             .withPlanId(planId)
             .withFileScanTasks(initial.first())
-            .withSpecsById(table.specs());
+            .withSpecsById(specsForTasks(table, initial.first()));
 
     if (!nextPlanTasks.isEmpty()) {
       builder.withPlanTasks(nextPlanTasks);
@@ -911,7 +918,7 @@ public class CatalogHandlers {
         .withPlanStatus(PlanStatus.COMPLETED)
         .withFileScanTasks(initial.first())
         .withPlanTasks(IN_MEMORY_PLANNING_STATE.nextPlanTask(initial.second()))
-        .withSpecsById(table.specs())
+        .withSpecsById(specsForTasks(table, initial.first()))
         .build();
   }
 
@@ -932,7 +939,7 @@ public class CatalogHandlers {
     return FetchScanTasksResponse.builder()
         .withFileScanTasks(fileScanTasks)
         .withPlanTasks(IN_MEMORY_PLANNING_STATE.nextPlanTask(planTask))
-        .withSpecsById(table.specs())
+        .withSpecsById(specsForTasks(table, fileScanTasks))
         .build();
   }
 
@@ -976,6 +983,91 @@ public class CatalogHandlers {
     configuredScan = configuredScan.caseSensitive(request.caseSensitive());
 
     return configuredScan;
+  }
+
+  private static TableScan scanSnapshot(
+      Table table, TableScan tableScan, long snapshotId, boolean useSnapshotSchema) {
+    if (tableScan instanceof RESTTableScan restTableScan) {
+      return restTableScan.useSnapshot(snapshotId, useSnapshotSchema);
+    }
+
+    if (isDefaultDataTableScan(tableScan)) {
+      if (!useSnapshotSchema || requiresSnapshotSpecRebinding(table, snapshotId)) {
+        return newDataTableScan(table, useSnapshotSchema).useSnapshot(snapshotId);
+      }
+
+      return tableScan.useSnapshot(snapshotId);
+    }
+
+    if (useSnapshotSchema
+        && tableScan instanceof DataTableScan
+        && requiresSnapshotSpecRebinding(table, snapshotId)) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Scan %s cannot plan snapshot %s with its snapshot schema",
+              tableScan.getClass().getName(), snapshotId));
+    }
+
+    TableScan snapshotScan = tableScan.useSnapshot(snapshotId);
+    if (!useSnapshotSchema && !snapshotScan.schema().sameSchema(table.schema())) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Scan %s cannot plan snapshot %s with the current table schema",
+              tableScan.getClass().getName(), snapshotId));
+    }
+
+    return snapshotScan;
+  }
+
+  private static boolean requiresSnapshotSpecRebinding(Table table, long snapshotId) {
+    Snapshot currentSnapshot = table.currentSnapshot();
+    return (currentSnapshot == null || currentSnapshot.snapshotId() == snapshotId)
+        && !SnapshotUtil.schemaFor(table, snapshotId).sameSchema(table.schema());
+  }
+
+  private static boolean isDefaultDataTableScan(TableScan scan) {
+    return scan.getClass().equals(DataTableScan.class);
+  }
+
+  private static TableScan newDataTableScan(Table table, boolean useSnapshotSchema) {
+    TableScan scan =
+        new SchemaAwareDataTableScan(
+            table, table.schema(), TableScanContext.empty(), useSnapshotSchema);
+    if (table instanceof BaseTable baseTable) {
+      scan = scan.metricsReporter(baseTable.reporter());
+    }
+
+    return scan;
+  }
+
+  private static Map<Integer, PartitionSpec> specsForTasks(Table table, List<FileScanTask> tasks) {
+    if (tasks == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<Integer, PartitionSpec> specsById = Maps.newHashMap();
+    for (FileScanTask task : tasks) {
+      specsById.put(task.spec().specId(), task.spec());
+      for (DeleteFile delete : task.deletes()) {
+        specsById.computeIfAbsent(
+            delete.specId(),
+            specId -> {
+              PartitionSpec spec = table.specs().get(specId);
+              Preconditions.checkArgument(spec != null, "Cannot find partition spec %s", specId);
+              return spec.toUnbound().bind(task.spec().schema(), true);
+            });
+      }
+    }
+
+    return specsById;
+  }
+
+  private static Map<Integer, PartitionSpec> rebindSpecs(
+      Map<Integer, PartitionSpec> specs, Schema schema) {
+    ImmutableMap.Builder<Integer, PartitionSpec> reboundSpecs =
+        ImmutableMap.builderWithExpectedSize(specs.size());
+    specs.forEach((specId, spec) -> reboundSpecs.put(specId, spec.toUnbound().bind(schema, true)));
+    return reboundSpecs.build();
   }
 
   /**
@@ -1055,5 +1147,35 @@ public class CatalogHandlers {
                 IN_MEMORY_PLANNING_STATE.markAsyncPlanAsComplete(asyncPlanId);
               }
             });
+  }
+
+  private static final class SchemaAwareDataTableScan extends DataTableScan {
+    private final boolean useSnapshotSchema;
+
+    private SchemaAwareDataTableScan(
+        Table table, Schema schema, TableScanContext context, boolean useSnapshotSchema) {
+      super(table, schema, context);
+      this.useSnapshotSchema = useSnapshotSchema;
+    }
+
+    @Override
+    protected boolean useSnapshotSchema() {
+      return useSnapshotSchema;
+    }
+
+    @Override
+    protected Map<Integer, PartitionSpec> specs() {
+      Map<Integer, PartitionSpec> specs = table().specs();
+      if (!useSnapshotSchema || tableSchema().sameSchema(table().schema())) {
+        return specs;
+      }
+
+      return rebindSpecs(specs, tableSchema());
+    }
+
+    @Override
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new SchemaAwareDataTableScan(table, schema, context, useSnapshotSchema);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataTableScan;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
@@ -110,7 +111,7 @@ class RESTTableScan extends DataTableScan {
     this.supportedEndpoints = supportedEndpoints;
     this.parserContext =
         ParserContext.builder()
-            .add("specsById", table.specs())
+            .add("specsById", specs())
             .add("caseSensitive", context().caseSensitive())
             .build();
     this.catalogProperties = catalogProperties;
@@ -138,6 +139,26 @@ class RESTTableScan extends DataTableScan {
   }
 
   @Override
+  protected Map<Integer, PartitionSpec> specs() {
+    Map<Integer, PartitionSpec> specs = table().specs();
+    Schema scanSchema = tableSchema();
+    if (scanSchema.sameSchema(table().schema())) {
+      return specs;
+    }
+
+    ImmutableMap.Builder<Integer, PartitionSpec> reboundSpecs =
+        ImmutableMap.builderWithExpectedSize(specs.size());
+    specs.forEach(
+        (specId, spec) -> reboundSpecs.put(specId, spec.toUnbound().bind(scanSchema, true)));
+    return reboundSpecs.build();
+  }
+
+  @Override
+  protected boolean useSnapshotSchema() {
+    return useSnapshotSchema;
+  }
+
+  @Override
   public TableScan useRef(String name) {
     SnapshotRef ref = table().refs().get(name);
     this.useSnapshotSchema = ref != null && ref.isTag();
@@ -146,7 +167,11 @@ class RESTTableScan extends DataTableScan {
 
   @Override
   public TableScan useSnapshot(long snapshotId) {
-    this.useSnapshotSchema = true;
+    return useSnapshot(snapshotId, true);
+  }
+
+  TableScan useSnapshot(long snapshotId, boolean shouldUseSnapshotSchema) {
+    this.useSnapshotSchema = shouldUseSnapshotSchema;
     return super.useSnapshot(snapshotId);
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -44,7 +44,9 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DataTableScan;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataTableUtils;
@@ -53,7 +55,10 @@ import org.apache.iceberg.Scan;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.TableScanContext;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expressions;
@@ -210,6 +215,59 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
     @Override
     public TestPlanningBehavior.Builder apply(TestPlanningBehavior.Builder builder) {
       return this.configurer.apply(builder);
+    }
+  }
+
+  private enum ScanTaskResponseMode
+      implements Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> {
+    SYNCHRONOUS(TestPlanningBehavior.Builder::synchronous),
+    ASYNCHRONOUS(TestPlanningBehavior.Builder::asynchronous),
+    PAGINATED(TestPlanningBehavior.Builder::synchronousWithPagination);
+
+    private final Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> configurer;
+
+    ScanTaskResponseMode(
+        Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> configurer) {
+      this.configurer = configurer;
+    }
+
+    @Override
+    public TestPlanningBehavior.Builder apply(TestPlanningBehavior.Builder builder) {
+      return this.configurer.apply(builder);
+    }
+  }
+
+  private static class CustomScanTable extends BaseTable {
+    private final boolean useSnapshotSchema;
+
+    private CustomScanTable(BaseTable table, boolean useSnapshotSchema) {
+      super(table.operations(), table.name(), table.reporter());
+      this.useSnapshotSchema = useSnapshotSchema;
+    }
+
+    @Override
+    public TableScan newScan() {
+      return new CustomDataTableScan(this, schema(), TableScanContext.empty(), useSnapshotSchema);
+    }
+  }
+
+  private static class CustomDataTableScan extends DataTableScan {
+    private final boolean useSnapshotSchema;
+
+    private CustomDataTableScan(
+        Table table, Schema schema, TableScanContext context, boolean useSnapshotSchema) {
+      super(table, schema, context);
+      this.useSnapshotSchema = useSnapshotSchema;
+    }
+
+    @Override
+    protected boolean useSnapshotSchema() {
+      return useSnapshotSchema;
+    }
+
+    @Override
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new CustomDataTableScan(table, schema, context, useSnapshotSchema);
     }
   }
 
@@ -683,6 +741,17 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
         .isEqualTo(100L);
   }
 
+  @Test
+  void synchronousScanPlanningWithZeroMinRowsRequested() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Table table = restTableFor(restCatalog, "zero_min_rows_requested_table");
+    setParserContext(table);
+
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().minRowsRequested(0L).planFiles()) {
+      assertThat(tasks).isEmpty();
+    }
+  }
+
   @ParameterizedTest
   @EnumSource(PlanningMode.class)
   void remoteScanPlanningDeletesCancellation(
@@ -912,6 +981,299 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
       assertThat(request.useSnapshotSchema())
           .as("useRef() with a branch should not use snapshot schema")
           .isFalse();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void rejectsCustomScanThatCannotHonorRequestedSchema(boolean useSnapshotSchema) {
+    TableIdentifier identifier = TableIdentifier.of(NS, "unsupported_custom_scan");
+    backendCatalog.createNamespace(NS);
+    Table table = backendCatalog.buildTable(identifier, SCHEMA).withPartitionSpec(SPEC).create();
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().addColumn("new_col", Types.IntegerType.get()).commit();
+
+    CustomScanTable customTable = new CustomScanTable((BaseTable) table, true);
+    Catalog catalog = Mockito.mock(Catalog.class);
+    Mockito.when(catalog.loadTable(identifier)).thenReturn(customTable);
+    PlanTableScanRequest request =
+        PlanTableScanRequest.builder()
+            .withSnapshotId(snapshotId)
+            .withUseSnapshotSchema(useSnapshotSchema)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                CatalogHandlers.planTableScan(
+                    catalog, identifier, request, scan -> false, scan -> 100))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("cannot plan snapshot");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void plansWithCompatibleCustomScan(boolean useSnapshotSchema) {
+    TableIdentifier identifier = TableIdentifier.of(NS, "compatible_custom_scan");
+    backendCatalog.createNamespace(NS);
+    Table table = backendCatalog.buildTable(identifier, SCHEMA).withPartitionSpec(SPEC).create();
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.updateSchema().addColumn("new_col", Types.IntegerType.get()).commit();
+    table.newAppend().appendFile(FILE_B).commit();
+
+    CustomScanTable customTable = new CustomScanTable((BaseTable) table, useSnapshotSchema);
+    Catalog catalog = Mockito.mock(Catalog.class);
+    Mockito.when(catalog.loadTable(identifier)).thenReturn(customTable);
+    PlanTableScanRequest request =
+        PlanTableScanRequest.builder()
+            .withSnapshotId(snapshotId)
+            .withUseSnapshotSchema(useSnapshotSchema)
+            .build();
+
+    PlanTableScanResponse response =
+        CatalogHandlers.planTableScan(catalog, identifier, request, scan -> false, scan -> 100);
+
+    assertThat(response.fileScanTasks())
+        .singleElement()
+        .satisfies(
+            task -> {
+              if (useSnapshotSchema) {
+                assertThat(task.schema().findField("new_col")).isNull();
+              } else {
+                assertThat(task.schema().findField("new_col")).isNotNull();
+              }
+            });
+  }
+
+  @Test
+  void remoteSnapshotScanUsesSnapshotSchemaAfterSchemaEvolution() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "data", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("id").build();
+    TableIdentifier identifier = TableIdentifier.of(NS, "snapshot_schema_after_evolution");
+
+    restCatalog.createNamespace(NS);
+    Table table = restCatalog.buildTable(identifier, schema).withPartitionSpec(spec).create();
+    DataFile file =
+        DataFiles.builder(spec)
+            .withPath("/path/to/current-snapshot.parquet")
+            .withPartitionPath("id=1")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    table.newAppend().appendFile(file).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    setParserContext(table);
+
+    table.updateSchema().updateColumn("id", Types.LongType.get()).commit();
+    table.refresh();
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(snapshotId);
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(snapshotId).filter(Expressions.equal("id", 1)).planFiles()) {
+      assertThat(Lists.newArrayList(tasks))
+          .singleElement()
+          .satisfies(
+              task -> {
+                assertThat(task.schema().findField("id").type()).isEqualTo(Types.IntegerType.get());
+                assertThat(task.file().partition().get(0, Integer.class)).isEqualTo(1);
+              });
+    }
+  }
+
+  @Test
+  void remoteSnapshotScanUsesSnapshotSchemaWhenMainHasNoSnapshot() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Table table = createTableWithScanPlanning(restCatalog, "snapshot_schema_without_main_snapshot");
+    String branch = "test-branch";
+
+    table.newAppend().appendFile(FILE_A).toBranch(branch).commit();
+    table.refresh();
+    assertThat(table.currentSnapshot()).isNull();
+    long snapshotId = table.snapshot(branch).snapshotId();
+    setParserContext(table);
+
+    table.updateSchema().deleteColumn("id").commit();
+    table.refresh();
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(snapshotId).filter(Expressions.equal("id", 1)).planFiles()) {
+      assertThat(Lists.newArrayList(tasks))
+          .singleElement()
+          .satisfies(task -> assertThat(task.schema().findField("id")).isNotNull());
+    }
+  }
+
+  @ParameterizedTest
+  @EnumSource(ScanTaskResponseMode.class)
+  void remoteSnapshotScanSerializesPartitionsUsingSnapshotSchema(
+      Function<TestPlanningBehavior.Builder, TestPlanningBehavior.Builder> planMode)
+      throws IOException {
+    configurePlanningBehavior(planMode);
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "data", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("id").build();
+    TableIdentifier identifier = TableIdentifier.of(NS, "snapshot_partition_type_evolution");
+
+    restCatalog.createNamespace(NS);
+    Table table = restCatalog.buildTable(identifier, schema).withPartitionSpec(spec).create();
+    DataFile oldFile =
+        DataFiles.builder(spec)
+            .withPath("/path/to/old.parquet")
+            .withPartitionPath("id=1")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    DataFile secondOldFile =
+        DataFiles.builder(spec)
+            .withPath("/path/to/second-old.parquet")
+            .withPartitionPath("id=2")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    table.newAppend().appendFile(oldFile).appendFile(secondOldFile).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    setParserContext(table);
+
+    table.updateSchema().updateColumn("id", Types.LongType.get()).commit();
+    PartitionSpec updatedSpec = table.spec();
+    DataFile newFile =
+        DataFiles.builder(updatedSpec)
+            .withPath("/path/to/new.parquet")
+            .withPartitionPath("id=3")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    table.newAppend().appendFile(newFile).commit();
+    table.refresh();
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(snapshotId).planFiles()) {
+      assertThat(Lists.newArrayList(tasks))
+          .extracting(task -> task.file().partition().get(0, Integer.class))
+          .containsExactlyInAnyOrder(1, 2);
+    }
+  }
+
+  @Test
+  void remoteBranchScanUsesCurrentSchemaWhenMainHasNoSnapshot() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Table table = createTableWithScanPlanning(restCatalog, "branch_schema_without_main_snapshot");
+    String branch = "test-branch";
+
+    table.newAppend().appendFile(FILE_A).toBranch(branch).commit();
+    table.refresh();
+    assertThat(table.currentSnapshot()).isNull();
+
+    table.updateSchema().addColumn("new_col", Types.IntegerType.get()).commit();
+    table.refresh();
+    setParserContext(table);
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useRef(branch).filter(Expressions.isNull("new_col")).planFiles()) {
+      assertThat(Lists.newArrayList(tasks))
+          .singleElement()
+          .satisfies(task -> assertThat(task.schema().findField("new_col")).isNotNull());
+    }
+  }
+
+  @Test
+  void remoteBranchScanPreservesSchemaIfBranchIsRemovedBeforePlanning() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    TableIdentifier identifier = TableIdentifier.of(NS, "removed_branch_scan");
+    Table table = createTableWithScanPlanning(restCatalog, identifier);
+    String branch = "test-branch";
+
+    table.newAppend().appendFile(FILE_A).toBranch(branch).commit();
+    table.refresh();
+    long snapshotId = table.snapshot(branch).snapshotId();
+
+    table.updateSchema().addColumn("new_col", Types.IntegerType.get()).commit();
+    table.refresh();
+    setParserContext(table);
+
+    TableScan branchScan = table.newScan().useRef(branch).filter(Expressions.isNull("new_col"));
+    table.manageSnapshots().removeBranch(branch).commit();
+
+    try (CloseableIterable<FileScanTask> tasks = branchScan.planFiles()) {
+      assertThat(Lists.newArrayList(tasks))
+          .singleElement()
+          .satisfies(task -> assertThat(task.schema().findField("new_col")).isNotNull());
+    }
+
+    restCatalog.invalidateTable(identifier);
+    PlanTableScanRequest forwardedRequest =
+        PlanTableScanRequest.builder()
+            .withSnapshotId(snapshotId)
+            .withUseSnapshotSchema(false)
+            .withFilter(Expressions.isNull("new_col"))
+            .build();
+    PlanTableScanResponse forwardedResponse =
+        CatalogHandlers.planTableScan(
+            restCatalog, identifier, forwardedRequest, scan -> false, scan -> 100);
+    PlanTableScanRequest innerRequest = captureLastPlanRequest();
+    assertThat(innerRequest.useSnapshotSchema()).isFalse();
+    assertThat(innerRequest.select()).contains("new_col");
+    assertThat(forwardedResponse.planStatus()).isEqualTo(PlanStatus.COMPLETED);
+  }
+
+  @Test
+  void remoteScanSerializesDeleteFilesFromAnotherSpec() throws IOException {
+    configurePlanningBehavior(TestPlanningBehavior.Builder::synchronous);
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "data", Types.StringType.get()));
+    PartitionSpec oldSpec = PartitionSpec.unpartitioned();
+    TableIdentifier identifier = TableIdentifier.of(NS, "delete_file_from_another_spec");
+
+    restCatalog.createNamespace(NS);
+    Table table =
+        restCatalog
+            .buildTable(identifier, schema)
+            .withPartitionSpec(oldSpec)
+            .withProperty(TableProperties.FORMAT_VERSION, "2")
+            .create();
+    table.updateSpec().addField("data").commit();
+    PartitionSpec dataSpec = table.spec();
+    DataFile dataFile =
+        DataFiles.builder(dataSpec)
+            .withPath("/path/to/data-with-new-spec.parquet")
+            .withPartitionPath("data=value")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    DeleteFile deleteFile =
+        FileMetadata.deleteFileBuilder(oldSpec)
+            .ofEqualityDeletes(1)
+            .withPath("/path/to/delete-with-old-spec.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    table.newAppend().appendFile(dataFile).commit();
+    table.newRowDelta().addDeletes(deleteFile).commit();
+    setParserContext(table);
+
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+      assertThat(Lists.newArrayList(tasks))
+          .singleElement()
+          .satisfies(
+              task -> {
+                assertThat(task.spec().specId()).isEqualTo(dataSpec.specId());
+                assertThat(task.deletes())
+                    .singleElement()
+                    .satisfies(
+                        delete -> {
+                          assertThat(delete.specId()).isEqualTo(oldSpec.specId());
+                          assertThat(delete.location()).isEqualTo(deleteFile.location());
+                        });
+              });
     }
   }
 


### PR DESCRIPTION
## Summary

- Preserve snapshot-versus-branch schema selection during server-side REST scan planning.
- Serialize and decode planned tasks with partition specs bound to the selected scan schema.
- Cover schema-only updates, tables whose main branch has no snapshot, removed branches, pagination, and asynchronous planning.

## Why

REST scan requests carry an exact snapshot ID and a `use-snapshot-schema` flag. The server previously ignored that flag, while task serialization and decoding always used the table's current partition specs. After schema evolution, that can bind filters or partition values to the wrong schema.

The general `SnapshotScan` shortcuts cannot be broadened safely because current-schema scans rely on them. This change therefore leaves core scan behavior untouched and handles the REST boundary directly. It also preserves exact snapshot IDs when a branch changes or is removed before server-side planning.

No public Java API or REST wire-format changes are included.

## Validation

- Full `TestRESTScanPlanning`, including synchronous, asynchronous, and paginated regressions
- Full `:iceberg-core:test`
- `spotlessCheck`
- `:iceberg-core:revapi`
- Previously failing Spark 4.1 regression methods, covering four parameterized executions

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Investigate REST snapshot-schema planning after schema evolution, keep the fix scoped away from core scan semantics, add regression coverage, and validate the draft PR.
